### PR TITLE
修复了pymss-studio针对多个CUDA设备选择无效的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,19 @@ dist/
 # Tauri / Rust build
 src-tauri/target/
 src-tauri/target/**
+src-tauri/gen/schemas/linux-schema.json
 
 # Python cache
 __pycache__/
 *.py[cod]
+*.pyd
+*.so
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
 .python-version
 .venv/
 venv/

--- a/python/worker_infer.py
+++ b/python/worker_infer.py
@@ -109,6 +109,45 @@ def _store_dirs_for_selected_stems(output_dir: str, selected_stems: list[str]) -
 def _normalize_output_layout(value: Any) -> str:
     return "flat" if str(value or "").strip().lower() == "flat" else "folders"
 
+
+def _normalize_device_ids(value: Any) -> list[int]:
+    raw_ids = value if isinstance(value, list) else [value]
+    device_ids: list[int] = []
+    for raw_id in raw_ids:
+        try:
+            device_id = int(raw_id)
+        except (TypeError, ValueError):
+            continue
+        if device_id >= 0 and device_id not in device_ids:
+            device_ids.append(device_id)
+    return device_ids or [0]
+
+
+def _resolve_separator_device(device: Any, device_ids: Any) -> tuple[str, list[int], str]:
+    requested_device = str(device or "auto").strip().lower() or "auto"
+    normalized_ids = _normalize_device_ids(device_ids)
+    if requested_device != "cuda":
+        return requested_device, normalized_ids, requested_device
+
+    # pymss currently leaves an explicit `device="cuda"` unchanged. PyTorch
+    # interprets that bare value as the process default CUDA device (normally
+    # cuda:0), so the selected device id would otherwise be ignored. Let
+    # pymss's auto path resolve the indexed CUDA device from device_ids.
+    try:
+        import torch
+    except ImportError as exc:
+        raise RuntimeError("CUDA was selected, but PyTorch is not installed") from exc
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA was selected, but CUDA is not available")
+    device_count = int(torch.cuda.device_count())
+    invalid_ids = [device_id for device_id in normalized_ids if device_id >= device_count]
+    if invalid_ids:
+        raise RuntimeError(
+            f"CUDA device id(s) {invalid_ids} are unavailable; detected {device_count} CUDA device(s)"
+        )
+    return "auto", normalized_ids, f"cuda:{normalized_ids[0]}"
+
+
 def _prepare_separator(
     *,
     payload: dict[str, Any],
@@ -123,8 +162,9 @@ def _prepare_separator(
     download = bool(payload.get("download", True))
     source = payload.get("source") or "modelscope"
     endpoint = payload.get("endpoint") or None
-    device = payload.get("device") or "auto"
-    device_ids = payload.get("deviceIds") or [0]
+    device, device_ids, resolved_device_label = _resolve_separator_device(
+        payload.get("device"), payload.get("deviceIds")
+    )
     output_format = payload.get("outputFormat") or "wav"
     selected_stems = _normalize_selected_stems(payload.get("selectedStems"))
     use_tta = bool(payload.get("useTta", False))
@@ -134,6 +174,11 @@ def _prepare_separator(
         payload.get("inferenceParamsVersion"),
     )
     audio_params = normalize_audio_params(payload.get("audioParams"))
+
+    emit("task_log", {
+        "level": "info",
+        "message": f"Runtime device: {resolved_device_label} (device_ids={device_ids})",
+    }, task_id=task_id)
 
     if download:
         emit("task_stage", {"stage": "downloading_model", "message": "Checking model files"}, task_id=task_id)
@@ -471,8 +516,12 @@ def cmd_infer(payload: dict[str, Any]) -> int:
     download = bool(payload.get("download", True))
     source = payload.get("source") or "modelscope"
     endpoint = payload.get("endpoint") or None
-    device = payload.get("device") or "auto"
-    device_ids = payload.get("deviceIds") or [0]
+    try:
+        device, device_ids, resolved_device_label = _resolve_separator_device(
+            payload.get("device"), payload.get("deviceIds")
+        )
+    except Exception as exc:
+        return emit_error("DEVICE_CONFIG_INVALID", str(exc), task_id=task_id)
     output_format = payload.get("outputFormat") or "wav"
     output_layout = _normalize_output_layout(payload.get("outputLayout"))
     save_as_folder = output_layout == "folders"
@@ -485,6 +534,11 @@ def cmd_infer(payload: dict[str, Any]) -> int:
         payload.get("inferenceParamsVersion"),
     )
     audio_params = normalize_audio_params(payload.get("audioParams"))
+
+    emit("task_log", {
+        "level": "info",
+        "message": f"Runtime device: {resolved_device_label} (device_ids={device_ids})",
+    }, task_id=task_id)
 
     last_reported_done: float | None = None
     last_reported_total: float | None = None

--- a/python/worker_workflows.py
+++ b/python/worker_workflows.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from worker_graph_workflows import is_graph_workflow_definition, run_graph_workflow_task
-from worker_infer import _normalize_output_layout, collect_outputs
+from worker_infer import _normalize_output_layout, _resolve_separator_device, collect_outputs
 from worker_protocol import emit, emit_error
 
 
@@ -72,8 +72,17 @@ def _candidate_commands(workflow_path: Path, input_path: str, output_dir: str, p
     endpoint = str(payload.get("endpoint") or "").strip()
     if endpoint:
         run_args.extend(["--endpoint", endpoint])
-    device = str(payload.get("device") or "").strip()
-    if device and device != "auto":
+    requested_device = str(payload.get("device") or "auto").strip().lower() or "auto"
+    device, device_ids, _resolved_device_label = _resolve_separator_device(
+        requested_device, payload.get("deviceIds")
+    )
+    if requested_device == "cuda":
+        # pymss's explicit `cuda` path currently loses the selected index,
+        # while `auto` plus device_ids resolves to cuda:<id> correctly.
+        run_args.extend(["--device", device])
+        for device_id in device_ids:
+            run_args.extend(["--device-id", str(device_id)])
+    elif device and device != "auto":
         run_args.extend(["--device", device])
     if payload.get("useTta"):
         run_args.append("--tta")


### PR DESCRIPTION
亲爱的开发团队：
        今天无意发现了这个项目，非常喜欢，上手体验了一下，遇到了些问题，于是进行了简单的修改，我也很期待我后续还能帮助到这个项目的发展中。我的环境是x64 的ArchLinux, 配有两张NV显卡。我下一步准备考虑打包一个Linux版的appimage试试看。


原来的代码在pymss 显式收到 device="cuda" 时直接保留字符串 "cuda"，没有把 device_ids[0] 拼成 cuda:1；而 PyTorch 的裸 "cuda" 默认就是 0 号卡。因此 CUDA 0/1 在 UI 上不同，实际都落到 CUDA 0。 同时工作流路径还额外漏传了 --device-id
上述问题均已修复，同时在日志显式添加Runtime device: cuda:1 (device_ids=[1])，方便确认