### PR TITLE
refactor(worker): 修改不同模式下文件的存储策略

### DIFF
--- a/python/worker_graph_workflows.py
+++ b/python/worker_graph_workflows.py
@@ -35,7 +35,6 @@ class AudioArtifact:
 @dataclass
 class SaveTarget:
     source_ref: str
-    output_dir: str
     output_label: str
 
 
@@ -46,10 +45,6 @@ def is_graph_workflow_definition(definition: Any) -> bool:
         and int(definition.get("version") or 0) == 2
         and isinstance(definition.get("graph"), dict)
     )
-
-
-def _is_record(value: Any) -> bool:
-    return isinstance(value, dict)
 
 
 def _safe_filename_part(value: str) -> str:
@@ -68,7 +63,7 @@ def _utility_title(node_type: str) -> str:
     }.get(node_type, node_type or "utility")
 
 
-def _read_graph(definition: dict[str, Any]) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]], dict[str, str]]:
+def _read_graph(definition: dict[str, Any]) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
     graph = definition.get("graph") if isinstance(definition.get("graph"), dict) else {}
     raw_nodes = graph.get("nodes") if isinstance(graph.get("nodes"), list) else []
     raw_edges = graph.get("edges") if isinstance(graph.get("edges"), list) else []
@@ -78,17 +73,7 @@ def _read_graph(definition: dict[str, Any]) -> tuple[dict[str, dict[str, Any]], 
         if isinstance(node, dict) and str(node.get("id") or "").strip()
     }
     edges = [edge for edge in raw_edges if isinstance(edge, dict)]
-    save_output_map: dict[str, str] = {}
-    for save_node in (node for node in nodes.values() if str(node.get("type") or "") == "save_outputs"):
-        save_outputs = save_node.get("data", {}).get("outputs", {}) if _is_record(save_node.get("data")) else {}
-        if not isinstance(save_outputs, dict):
-            continue
-        save_output_map.update({
-            str(key): str(value or "").strip()
-            for key, value in save_outputs.items()
-            if str(key or "").strip()
-        })
-    return nodes, edges, save_output_map
+    return nodes, edges
 
 
 def _node_position(node: dict[str, Any]) -> tuple[float, float]:
@@ -486,12 +471,56 @@ def _execute_separate_node(
                 cleanup()
 
 
+def _resolve_chain_label(
+    source_ref: str,
+    nodes: dict[str, dict[str, Any]],
+    edges: list[dict[str, Any]],
+) -> str:
+    """Build a chain-aware label for a save target.
+
+    Returns the label with upstream stem prefix, e.g. ``vocals_noreverb`` when a
+    separate node consuming ``vocals`` outputs ``noreverb``.
+    """
+    if not source_ref or source_ref == "input":
+        return ""
+
+    if source_ref.startswith("utility:"):
+        node_id = source_ref.split(":", 1)[1]
+        node = nodes.get(node_id, {})
+        own_label = _utility_title(str(node.get("type") or "utility"))
+        for edge in edges:
+            target = edge.get("target") if isinstance(edge.get("target"), dict) else {}
+            if str(target.get("nodeId") or "") == node_id:
+                upstream_ref = _source_ref_for_edge(nodes, edge)
+                if upstream_ref and upstream_ref != source_ref and upstream_ref != "input":
+                    parent = _resolve_chain_label(upstream_ref, nodes, edges)
+                    return f"{parent}_{own_label}" if parent else own_label
+        return own_label
+
+    if "." in source_ref:
+        node_id, stem = source_ref.split(".", 1)
+        node = nodes.get(node_id)
+        if node and str(node.get("type") or "") == "separate":
+            for edge in edges:
+                target = edge.get("target") if isinstance(edge.get("target"), dict) else {}
+                if str(target.get("nodeId") or "") == node_id and str(target.get("portId") or "") == "input":
+                    upstream_ref = _source_ref_for_edge(nodes, edge)
+                    if upstream_ref and upstream_ref != "input":
+                        parent = _resolve_chain_label(upstream_ref, nodes, edges)
+                        return f"{parent}_{stem}" if parent else stem
+                    return stem
+            return stem
+        return stem
+
+    return source_ref
+
+
 def _save_targets_for_graph(
     nodes: dict[str, dict[str, Any]],
     edges: list[dict[str, Any]],
-    save_output_map: dict[str, str],
 ) -> list[SaveTarget]:
     targets: list[SaveTarget] = []
+    seen_labels: set[str] = set()
     save_node_ids = {
         node_id
         for node_id, node in nodes.items()
@@ -504,19 +533,17 @@ def _save_targets_for_graph(
         source_ref = _source_ref_for_edge(nodes, edge)
         if not source_ref:
             continue
-        output_dir = save_output_map.get(source_ref) or source_ref.replace("utility:", "")
-        if source_ref.startswith("utility:"):
-            source_node_id = source_ref.split(":", 1)[1]
-            source_node = nodes.get(source_node_id, {})
-            fallback_label = _utility_title(str(source_node.get("type") or "utility"))
-        else:
-            fallback_label = source_ref.split(".", 1)[1] if "." in source_ref else source_ref
-        folder_name = Path(str(output_dir).rstrip("\\/")).name if str(output_dir).strip() else ""
-        output_label = _safe_filename_part(folder_name or fallback_label)
+        chain_label = _resolve_chain_label(source_ref, nodes, edges)
+        if not chain_label:
+            continue
+        output_label = _safe_filename_part(chain_label)
+        # Guard against duplicate labels caused by duplicate save edges.
+        if output_label.lower() in seen_labels:
+            continue
+        seen_labels.add(output_label.lower())
         targets.append(
             SaveTarget(
                 source_ref=source_ref,
-                output_dir=str(output_dir).strip() or fallback_label,
                 output_label=output_label,
             )
         )
@@ -539,10 +566,10 @@ def run_graph_workflow_task(
         raise ValueError("Unsupported workflow definition for graph runtime.")
 
     workflow_defaults = definition.get("defaults") if isinstance(definition.get("defaults"), dict) else {}
-    nodes, edges, save_output_map = _read_graph(definition)
+    nodes, edges = _read_graph(definition)
     _validate_graph_definition(nodes, edges)
     execution_order = _build_execution_order(nodes, edges)
-    save_targets = _save_targets_for_graph(nodes, edges, save_output_map)
+    save_targets = _save_targets_for_graph(nodes, edges)
     source_path = Path(input_path)
     if not source_path.exists():
         raise FileNotFoundError(f"Input not found: {input_path}")
@@ -600,10 +627,8 @@ def run_graph_workflow_task(
 
         for target in save_targets:
             artifact = _resolve_artifact(artifacts, target.source_ref)
-            folder = task_output_dir / target.output_dir
-            folder.mkdir(parents=True, exist_ok=True)
             file_name = f"{_safe_filename_part(track_name)}_{target.output_label}.{output_format}"
-            output_path = folder / file_name
+            output_path = task_output_dir / file_name
             save_audio(str(output_path), _to_save_audio(artifact.audio), artifact.sample_rate, output_format, audio_params)
             outputs.append({
                 "stem": target.output_label,


### PR DESCRIPTION
- 在“平铺”模式下，存储路径为{output_dir}/{output_name}
- 在“分层”模式下，存储路径为{output_dir}/{input_basename}/{output_name}
- 对于工作流推理，output_name采用链式命名（例如vocal_noreverb），方便通过输出文件名追溯推理过程。

## 动机

在工作流推理/单模型推理中，存在两个明显的体验问题：
- 如果采用“分层”模式，输出文件夹下的子文件夹是人类不可读的`job_name`，无法快速分辨任务。
- 使用工作流推理时，后缀只保留最后一次分离的音轨名称，无法通过文件名快速了解分离逻辑；同时多个音轨在不同文件夹过于散乱。

## 改动点

仅改动`python/worker_graph_workflows.py`

- 新增`_resolve_chain_label`函数：递归追踪save目标的上游stem链。
- 去掉子文件夹：移除了`SaveTarget.output_dir`字段及相关的`folder = task_output_dir / target.output_dir + folder.mkdir`逻辑。文件直接写入`task_output_dir`根目录。
- 清理部分死代码

## 运行效果截图

1. 使用单模型推理，分层保存模式

<img width="966" height="255" alt="041189cf625940cb213ba04c5a1ad0ab" src="https://github.com/user-attachments/assets/938ab80b-25a6-47cc-848a-b5f0e115a79e" />

2. 使用工作流推理，分层保存模式

工作流json如下：

[workflows.json](https://github.com/user-attachments/files/29965159/workflows.json)

结果：

<img width="927" height="299" alt="62a12aaf1f3bd5c8c5f29ba295a45a66" src="https://github.com/user-attachments/assets/bf39c7c7-e444-4c35-91b7-57bd2ec0c697" />

3. 使用工作流推理，扁平保存（工作流一致）

结果：

<img width="872" height="458" alt="96c4dac679d672ed3e97c3a7dbf5aebc" src="https://github.com/user-attachments/assets/ceb57bec-0b50-4418-9941-6af95b993d73" />

均符合预期。



