### PR TITLE
fix: batch error handling, process lifecycle, and editor mix volume (14 bugs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Dependencies
 node_modules/
 .pnpm-store/
+pnpm-workspace.yaml
 
 # Frontend build
 dist/
@@ -8,7 +9,7 @@ dist/
 # Tauri / Rust build
 src-tauri/target/
 src-tauri/target/**
-src-tauri/gen/schemas/linux-schema.json
+src-tauri/gen/
 
 # Python cache
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ release/
 python-runtime/
 src-tauri/resources/
 src-tauri/tauri.bundle.resources.json
+run-dev.bat
 *.zip
 *.tar.zst
 *.dmg

--- a/python/worker_audio.py
+++ b/python/worker_audio.py
@@ -318,7 +318,8 @@ def cmd_export_editor_mix(payload: dict[str, Any]) -> int:
                     continue
 
                 segment = audio[:, offset:offset + duration_samples].copy()
-                volume = track_volume * float(clip.get("volume", 1.0) or 0)
+                raw_clip_volume = clip.get("volume")
+                volume = track_volume * (float(raw_clip_volume) if raw_clip_volume is not None else 1.0)
                 if volume <= 0:
                     continue
                 segment *= volume
@@ -349,10 +350,12 @@ def cmd_export_editor_mix(payload: dict[str, Any]) -> int:
                 segment = np.concatenate([segment, pad], axis=0)
             mix[:, start:start + segment.shape[-1]] += segment[:channels]
 
-        master_volume = float(project.get("masterVolume", 1.0) or 0)
+        raw_master_volume = project.get("masterVolume")
+        master_volume = float(raw_master_volume) if raw_master_volume is not None else 1.0
         if master_volume != 1.0:
             mix *= master_volume
-        master_pan = float(project.get("masterPan", 0.0) or 0.0)
+        raw_master_pan = project.get("masterPan")
+        master_pan = float(raw_master_pan) if raw_master_pan is not None else 0.0
         mix = _apply_stereo_pan(mix, master_pan)
 
         peak = float(np.max(np.abs(mix))) if mix.size else 0.0

--- a/python/worker_audio.py
+++ b/python/worker_audio.py
@@ -152,7 +152,7 @@ def cmd_waveform_peaks(payload: dict[str, Any]) -> int:
     path = Path(path_value)
     resolution = int(payload.get("resolution") or 1400)
     resolution = max(80, min(12000, resolution))
-    cache_dir = Path(payload.get("cacheDir") or path.parent / ".pymss-peaks")
+    cache_dir = Path(payload.get("cacheDir") or path.parent / ".pymss-peaks").resolve()
     cache_dir.mkdir(parents=True, exist_ok=True)
     cache_key = hashlib.sha1(str(path.resolve()).encode("utf-8", errors="replace")).hexdigest()[:16]
     cache_name = f"{path.stem}_{cache_key}_{resolution}.json"
@@ -286,8 +286,10 @@ def cmd_export_editor_mix(payload: dict[str, Any]) -> int:
             if has_solo and not track.get("solo"):
                 continue
 
-            track_volume = float(track.get("volume", 1.0) or 0)
-            track_pan = float(track.get("pan", 0.0) or 0.0)
+            volume = track.get("volume")
+            track_volume = float(volume) if volume is not None else 1.0
+            pan = track.get("pan")
+            track_pan = float(pan) if pan is not None else 0.0
             if track_volume <= 0:
                 continue
 

--- a/python/worker_graph_workflows.py
+++ b/python/worker_graph_workflows.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import numpy as np
 
-from worker_infer import JsonLogHandler, _prepare_separator, normalize_audio_params, resolve_pymss_output_dir
+from worker_infer import JsonLogHandler, _close_separator, _prepare_separator, normalize_audio_params, resolve_pymss_output_dir
 from worker_protocol import emit
 
 
@@ -444,7 +444,8 @@ def _execute_separate_node(
         logger=logger,
     )
     try:
-        sample_rate = int(separator.config.audio.get("sample_rate", source.sample_rate))
+        audio_config = getattr(getattr(separator, "config", {}), "audio", {}) or {}
+        sample_rate = int(audio_config.get("sample_rate", source.sample_rate))
         from pymss.workflow import _ensure_sample_rate
 
         model_audio = _to_model_audio(_ensure_sample_rate(_normalize_artifact_audio(source.audio), source.sample_rate, sample_rate))
@@ -462,13 +463,7 @@ def _execute_separate_node(
             )
         return selected
     finally:
-        close = getattr(separator, "close", None)
-        if callable(close):
-            close()
-        else:
-            cleanup = getattr(separator, "del_cache", None)
-            if callable(cleanup):
-                cleanup()
+        _close_separator(separator)
 
 
 def _resolve_chain_label(

--- a/python/worker_infer.py
+++ b/python/worker_infer.py
@@ -487,6 +487,7 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
             logger=logger,
         )
         failed = False
+        succeeded_task_ids: set[str] = set()
         for item in batch_tasks:
             task_id = item["taskId"]
             active_task_id = task_id
@@ -505,6 +506,7 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
                 "outputDir": str(Path(task_output).resolve()),
                 "outputFormat": output_format,
             }, task_id=task_id)
+            succeeded_task_ids.add(task_id)
         active_task_id = None
         return 1 if failed else 0
     except Exception as exc:

--- a/python/worker_infer.py
+++ b/python/worker_infer.py
@@ -468,6 +468,7 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
 
     failed = False
     succeeded_task_ids: set[str] = set()
+    failed_task_ids: set[str] = set()
     try:
         Path(output_root).mkdir(parents=True, exist_ok=True)
         for item in batch_tasks:
@@ -495,6 +496,7 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
             if Path(item["input"]).name not in {Path(name).name for name in success_files}:
                 emit_error("INFERENCE_FAILED", f"Batch separation did not produce outputs for {Path(item['input']).name}", task_id=task_id)
                 failed = True
+                failed_task_ids.add(task_id)
                 continue
             task_output = resolve_pymss_output_dir(output_root, success_files, item["input"], save_as_folder)
             emit("task_stage", {"stage": "writing_output", "message": "Collecting outputs"}, task_id=task_id)
@@ -509,6 +511,7 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
         active_task_id = None
         return 1 if failed else 0
     except Exception as exc:
+        active_task_id = None
         msg = str(exc)
         detail = traceback.format_exc()
         lowered = msg.lower()
@@ -519,7 +522,7 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
         else:
             code = "INFERENCE_FAILED"
         for item in batch_tasks:
-            if item["taskId"] not in succeeded_task_ids:
+            if item["taskId"] not in succeeded_task_ids and item["taskId"] not in failed_task_ids:
                 emit_error(code, msg, detail, task_id=item["taskId"])
         return 1
     finally:

--- a/python/worker_infer.py
+++ b/python/worker_infer.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from worker_audio import _apply_stereo_pan, _equal_power_fade, _read_audio, _resample_audio
 from worker_models import _derive_overlap_size_from_num_overlap
 from worker_protocol import _as_bool, _as_float, _as_int, emit, emit_error
 

--- a/python/worker_infer.py
+++ b/python/worker_infer.py
@@ -518,7 +518,8 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
         else:
             code = "INFERENCE_FAILED"
         for item in batch_tasks:
-            emit_error(code, msg, detail, task_id=item["taskId"])
+            if item["taskId"] not in succeeded_task_ids:
+                emit_error(code, msg, detail, task_id=item["taskId"])
         return 1
     finally:
         if logger is not None and log_handler is not None:

--- a/python/worker_infer.py
+++ b/python/worker_infer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import os
 import traceback
 from datetime import datetime
@@ -26,13 +27,17 @@ class JsonLogHandler:
         return True
 
 
-def collect_outputs(output_dir: str, success_files: list[str], output_format: str) -> list[dict[str, str]]:
+def collect_outputs(output_dir: str, success_files: list[str], output_format: str, min_mtime: float = 0) -> list[dict[str, str]]:
     base = Path(output_dir)
     outputs: list[dict[str, str]] = []
     if not base.exists():
         return outputs
-    success_stems = {Path(name).stem for name in success_files}
+    success_stems = sorted({Path(name).stem for name in success_files}, key=len, reverse=True)
     for path in base.rglob(f"*.{output_format.lower()}"):
+        if not path.is_file():
+            continue
+        if min_mtime > 0 and path.stat().st_mtime < min_mtime:
+            continue
         if success_stems and not any(path.stem.startswith(stem + "_") or path.stem == stem for stem in success_stems):
             continue
         stem = path.stem.split("_")[-1] if "_" in path.stem else path.stem
@@ -65,6 +70,18 @@ def _emit_inference_error(exc: Exception, task_id: str) -> int:
         )
     return emit_error("INFERENCE_FAILED", message, traceback.format_exc(), task_id=task_id)
 
+def _purge_cuda() -> None:
+    try:
+        gc.collect()
+        import torch
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.reset_accumulated_memory_stats()
+    except Exception:
+        pass
+
+
 def _close_separator(separator: Any) -> None:
     if separator is None:
         return
@@ -79,13 +96,14 @@ def _close_separator(separator: Any) -> None:
             separator.del_cache()
         except Exception:
             pass
+    _purge_cuda()
 
 def _normalize_output_dir(value: Any) -> str:
     default_output_dir = os.environ.get("PYMSS_STUDIO_DEFAULT_OUTPUT_DIR")
     output_dir = value or default_output_dir or "results"
     output_path = Path(str(output_dir))
     if not output_path.is_absolute() and default_output_dir:
-        return str(Path(default_output_dir).parent / output_path)
+        return str(Path(default_output_dir).resolve().parent / output_path)
     return str(output_dir)
 
 def _normalize_selected_stems(value: Any) -> list[str]:
@@ -373,7 +391,8 @@ def normalize_audio_params(payload_audio_params: Any) -> dict[str, Any]:
         **defaults,
         **payload_audio_params,
     }
-    normalized["m4a_codec"] = "aac" if str(normalized.get("m4a_codec") or "").strip().lower() == "aac" else "aac"
+    codec = str(normalized.get("m4a_codec") or "").strip().lower()
+    normalized["m4a_codec"] = codec if codec in ("aac", "aac_at") else "aac"
     return normalized
 
 
@@ -383,6 +402,14 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
         return emit_error("INPUT_NOT_FOUND", "Missing batch tasks", task_id=payload.get("taskId") or None)
 
     root_task_id = str(payload.get("taskId") or raw_tasks[0].get("taskId") or f"sep_{int(datetime.now().timestamp())}")
+    model_name = payload.get("model")
+    if not model_name:
+        return emit_error("MODEL_NOT_FOUND", "Missing model name", task_id=root_task_id)
+    try:
+        _resolve_separator_device(payload.get("device"), payload.get("deviceIds"))
+    except Exception as exc:
+        return emit_error("DEVICE_CONFIG_INVALID", str(exc), task_id=root_task_id)
+
     output_root = _normalize_output_dir(payload.get("output"))
     output_format = payload.get("outputFormat") or "wav"
     output_layout = _normalize_output_layout(payload.get("outputLayout"))
@@ -431,16 +458,14 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
         last_reported_done = done_value
         last_reported_total = total_value
         last_progress_message = safe_message
-        targets = [active_task_id] if active_task_id else [item["taskId"] for item in batch_tasks]
-        for task_id in targets:
-            if not task_id:
-                continue
-            emit("task_progress", {
-                "stage": "separating",
-                "message": safe_message,
-                "done": done_value,
-                "total": total_value,
-            }, task_id=task_id)
+        if not active_task_id:
+            return
+        emit("task_progress", {
+            "stage": "separating",
+            "message": safe_message,
+            "done": done_value,
+            "total": total_value,
+        }, task_id=active_task_id)
 
     try:
         Path(output_root).mkdir(parents=True, exist_ok=True)
@@ -461,6 +486,7 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
             progress_callback=emit_batch_progress,
             logger=logger,
         )
+        failed = False
         for item in batch_tasks:
             task_id = item["taskId"]
             active_task_id = task_id
@@ -468,6 +494,7 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
             success_files = separator.process_folder(item["input"])
             if Path(item["input"]).name not in {Path(name).name for name in success_files}:
                 emit_error("INFERENCE_FAILED", f"Batch separation did not produce outputs for {Path(item['input']).name}", task_id=task_id)
+                failed = True
                 continue
             task_output = resolve_pymss_output_dir(output_root, success_files, item["input"], save_as_folder)
             emit("task_stage", {"stage": "writing_output", "message": "Collecting outputs"}, task_id=task_id)
@@ -479,10 +506,19 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
                 "outputFormat": output_format,
             }, task_id=task_id)
         active_task_id = None
-        return 0
+        return 1 if failed else 0
     except Exception as exc:
+        msg = str(exc)
+        detail = traceback.format_exc()
+        lowered = msg.lower()
+        if "download" in lowered:
+            code = "MODEL_DOWNLOAD_FAILED"
+        elif "model" in lowered:
+            code = "MODEL_NOT_FOUND"
+        else:
+            code = "INFERENCE_FAILED"
         for item in batch_tasks:
-            _emit_inference_error(exc, item["taskId"])
+            emit_error(code, msg, detail, task_id=item["taskId"])
         return 1
     finally:
         if logger is not None and log_handler is not None:
@@ -500,11 +536,7 @@ def cmd_infer(payload: dict[str, Any]) -> int:
     task_id = payload.get("taskId") or f"sep_{int(datetime.now().timestamp())}"
     model_name = payload.get("model")
     input_path = payload.get("input")
-    default_output_dir = os.environ.get("PYMSS_STUDIO_DEFAULT_OUTPUT_DIR")
-    output_dir = payload.get("output") or default_output_dir or "results"
-    output_path = Path(output_dir)
-    if not output_path.is_absolute() and default_output_dir:
-        output_dir = str(Path(default_output_dir).parent / output_path)
+    output_dir = _normalize_output_dir(payload.get("output"))
     if not model_name:
         return emit_error("MODEL_NOT_FOUND", "Missing model name", task_id=task_id)
     if not input_path:
@@ -644,38 +676,11 @@ def cmd_infer(payload: dict[str, Any]) -> int:
         emit("task_done", {"files": success_files, "outputs": outputs, "outputDir": str(Path(task_output).resolve()), "outputFormat": output_format}, task_id=task_id)
         return 0
     except Exception as exc:
-        message = str(exc)
-        lowered = message.lower()
-        if "no audio stream found" in lowered:
-            return emit_error(
-                "INPUT_AUDIO_STREAM_MISSING",
-                message,
-                traceback.format_exc(),
-                task_id=task_id,
-            )
-        if "invalid data found" in lowered or "could not open input" in lowered:
-            return emit_error(
-                "INPUT_MEDIA_UNSUPPORTED",
-                message,
-                traceback.format_exc(),
-                task_id=task_id,
-            )
-        return emit_error("INFERENCE_FAILED", message, traceback.format_exc(), task_id=task_id)
+        return _emit_inference_error(exc, task_id)
     finally:
         if logger is not None and log_handler is not None:
             try:
                 logger.removeHandler(log_handler)
             except Exception:
                 pass
-        if separator is not None:
-            close = getattr(separator, "close", None)
-            if callable(close):
-                try:
-                    close()
-                except Exception:
-                    pass
-            else:
-                try:
-                    separator.del_cache()
-                except Exception:
-                    pass
+        _close_separator(separator)

--- a/python/worker_infer.py
+++ b/python/worker_infer.py
@@ -466,6 +466,8 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
             "total": total_value,
         }, task_id=active_task_id)
 
+    failed = False
+    succeeded_task_ids: set[str] = set()
     try:
         Path(output_root).mkdir(parents=True, exist_ok=True)
         for item in batch_tasks:
@@ -485,8 +487,6 @@ def cmd_infer_batch(payload: dict[str, Any]) -> int:
             progress_callback=emit_batch_progress,
             logger=logger,
         )
-        failed = False
-        succeeded_task_ids: set[str] = set()
         for item in batch_tasks:
             task_id = item["taskId"]
             active_task_id = task_id

--- a/python/worker_models.py
+++ b/python/worker_models.py
@@ -586,7 +586,7 @@ def _path_size(path: Path) -> int:
         if path.is_file():
             return int(path.stat().st_size)
         if path.is_dir():
-            return sum(_path_size(child) for child in path.rglob("*") if child.is_file())
+            return sum(int(f.stat().st_size) for f in path.rglob("*") if f.is_file())
     except Exception:
         return 0
     return 0

--- a/python/worker_protocol.py
+++ b/python/worker_protocol.py
@@ -55,8 +55,12 @@ def load_payload(payload_arg: str | None) -> dict[str, Any]:
         return {}
     path = Path(payload_arg)
     if path.is_file():
-        return json.loads(path.read_text(encoding="utf-8"))
-    return json.loads(payload_arg)
+        result = json.loads(path.read_text(encoding="utf-8"))
+    else:
+        result = json.loads(payload_arg)
+    if not isinstance(result, dict):
+        raise ValueError(f"Payload must be a JSON object, got {type(result).__name__}")
+    return result
 
 
 def _as_int(value: Any) -> int | None:

--- a/python/worker_workflows.py
+++ b/python/worker_workflows.py
@@ -97,6 +97,10 @@ def _terminate_process(process: subprocess.Popen[bytes], task_id: str) -> None:
         process.kill()
     except Exception as exc:
         emit("task_log", {"level": "warning", "message": f"Failed to terminate workflow process for {task_id}: {exc}"}, task_id=task_id)
+    try:
+        process.wait(timeout=5)
+    except Exception:
+        pass
 
 
 def _run_workflow_cli(command: list[str], task_id: str) -> tuple[int, str]:
@@ -110,7 +114,8 @@ def _run_workflow_cli(command: list[str], task_id: str) -> tuple[int, str]:
         errors="replace",
     )
     lines: list[str] = []
-    assert process.stdout is not None
+    if process.stdout is None:
+        raise RuntimeError("Workflow process stdout is not available")
     timer = threading.Timer(6 * 3600, _terminate_process, args=(process, task_id))
     timer.start()
     try:
@@ -130,6 +135,10 @@ def _run_workflow_cli(command: list[str], task_id: str) -> tuple[int, str]:
         return process.wait(), "\n".join(lines[-40:])
     finally:
         timer.cancel()
+        try:
+            process.wait(timeout=5)
+        except Exception:
+            pass
 
 
 def _workflow_task_output_dir(output_dir: str, input_path: str, output_layout: str) -> Path:

--- a/python/worker_workflows.py
+++ b/python/worker_workflows.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 import traceback
 from pathlib import Path
 from typing import Any
 
 from worker_graph_workflows import is_graph_workflow_definition, run_graph_workflow_task
-from worker_infer import _normalize_output_layout, _resolve_separator_device, collect_outputs
+from worker_infer import _normalize_output_dir, _normalize_output_layout, _resolve_separator_device, collect_outputs
 from worker_protocol import emit, emit_error
-
-
-def _normalize_output_dir(value: Any) -> str:
-    text = str(value or "").strip()
-    return text or "results"
 
 
 def _write_workflow_definition(payload: dict[str, Any], task_id: str) -> Path:
@@ -65,6 +63,8 @@ def _candidate_commands(workflow_path: Path, input_path: str, output_dir: str, p
         str(audio_params.get("m4a_bit_rate") or "512k"),
         "--m4a-codec",
         str(audio_params.get("m4a_codec") or "aac"),
+        "--m4a-aac-at-quality",
+        str(audio_params.get("m4a_aac_at_quality") or 2),
     ]
     model_dir = str(payload.get("modelDir") or "").strip()
     if model_dir:
@@ -93,6 +93,13 @@ def _candidate_commands(workflow_path: Path, input_path: str, output_dir: str, p
     ]
 
 
+def _terminate_process(process: subprocess.Popen[bytes], task_id: str) -> None:
+    try:
+        process.kill()
+    except Exception as exc:
+        emit("task_log", {"level": "warning", "message": f"Failed to terminate workflow process for {task_id}: {exc}"}, task_id=task_id)
+
+
 def _run_workflow_cli(command: list[str], task_id: str) -> tuple[int, str]:
     emit("task_log", {"level": "info", "message": " ".join(command)}, task_id=task_id)
     process = subprocess.Popen(
@@ -105,20 +112,25 @@ def _run_workflow_cli(command: list[str], task_id: str) -> tuple[int, str]:
     )
     lines: list[str] = []
     assert process.stdout is not None
-    for line in process.stdout:
-        text = line.rstrip()
-        if not text:
-            continue
-        lines.append(text)
-        try:
-            event = json.loads(text)
-            if isinstance(event, dict) and isinstance(event.get("type"), str):
-                emit(event["type"], event.get("payload") if isinstance(event.get("payload"), dict) else {}, task_id=task_id)
+    timer = threading.Timer(6 * 3600, _terminate_process, args=(process, task_id))
+    timer.start()
+    try:
+        for line in process.stdout:
+            text = line.rstrip()
+            if not text:
                 continue
-        except Exception:
-            pass
-        emit("task_log", {"level": "info", "message": text}, task_id=task_id)
-    return process.wait(), "\n".join(lines[-40:])
+            lines.append(text)
+            try:
+                event = json.loads(text)
+                if isinstance(event, dict) and isinstance(event.get("type"), str):
+                    emit(event["type"], event.get("payload") if isinstance(event.get("payload"), dict) else {}, task_id=task_id)
+                    continue
+            except Exception:
+                pass
+            emit("task_log", {"level": "info", "message": text}, task_id=task_id)
+        return process.wait(), "\n".join(lines[-40:])
+    finally:
+        timer.cancel()
 
 
 def _workflow_task_output_dir(output_dir: str, input_path: str, output_layout: str) -> Path:
@@ -190,10 +202,12 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
         return _emit_workflow_batch_error(raw_tasks, root_task_id, "WORKFLOW_MISSING", "Workflow definition is required")
 
     failed = False
+    succeeded_task_ids: set[str] = set()
     try:
         graph_workflow = is_graph_workflow_definition(payload.get("workflow"))
         output_root = Path(output_dir)
         output_root.mkdir(parents=True, exist_ok=True)
+        batch_start_time = time.time()
         for item in batch_tasks:
             task_id = item["taskId"]
             input_path = item["input"]
@@ -216,6 +230,7 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
                     continue
                 emit("task_stage", {"stage": "writing_output", "message": "Collecting workflow outputs", "progress": 92}, task_id=task_id)
                 emit("task_done", result, task_id=task_id)
+                succeeded_task_ids.add(task_id)
                 continue
             failures: list[str] = []
             completed = False
@@ -230,16 +245,22 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
                     continue
 
                 emit("task_stage", {"stage": "writing_output", "message": "Collecting workflow outputs", "progress": 92}, task_id=task_id)
-                outputs = collect_outputs(str(task_output_dir), [Path(input_path).name], output_format)
+                outputs = collect_outputs(str(task_output_dir), [Path(input_path).name], output_format, min_mtime=batch_start_time)
                 files = [output["path"] for output in outputs]
                 if not files and task_output_dir.exists():
-                    files = [str(path) for path in task_output_dir.rglob("*") if path.is_file()]
+                    files = [str(path) for path in task_output_dir.rglob(f"*.{output_format}") if path.is_file() and path.stat().st_mtime >= batch_start_time]
+                    outputs = []
+                    for path in files:
+                        p = Path(path)
+                        stem = p.stem.split("_")[-1] if "_" in p.stem else p.stem
+                        outputs.append({"stem": stem, "path": path})
                 emit("task_done", {
                     "files": files,
                     "outputs": outputs,
                     "outputDir": str(task_output_dir.resolve()),
                     "outputFormat": output_format,
                 }, task_id=task_id)
+                succeeded_task_ids.add(task_id)
                 completed = True
                 break
             if not completed:
@@ -254,7 +275,8 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
     except Exception as exc:
         detail = traceback.format_exc()
         for item in batch_tasks:
-            emit_error("WORKFLOW_RUN_FAILED", str(exc), detail, task_id=item["taskId"])
+            if item["taskId"] not in succeeded_task_ids:
+                emit_error("WORKFLOW_RUN_FAILED", str(exc), detail, task_id=item["taskId"])
         return 1
 
 
@@ -277,6 +299,7 @@ def cmd_infer_workflow(payload: dict[str, Any]) -> int:
         return emit_error("WORKFLOW_MISSING", "Workflow definition is required", task_id=task_id)
 
     try:
+        workflow_start_time = time.time()
         source_path = Path(input_path)
         task_output_dir = _workflow_task_output_dir(output_dir, input_path, output_layout)
         Path(output_dir).mkdir(parents=True, exist_ok=True)
@@ -309,10 +332,15 @@ def cmd_infer_workflow(payload: dict[str, Any]) -> int:
                 continue
             if code == 0:
                 emit("task_stage", {"stage": "writing_output", "message": "Collecting workflow outputs", "progress": 92}, task_id=task_id)
-                outputs = collect_outputs(str(task_output_dir), [source_path.name], output_format)
+                outputs = collect_outputs(str(task_output_dir), [source_path.name], output_format, min_mtime=workflow_start_time)
                 files = [item["path"] for item in outputs]
                 if not files:
-                    files = [str(path) for path in task_output_dir.rglob("*") if path.is_file()]
+                    files = [str(path) for path in task_output_dir.rglob(f"*.{output_format}") if path.is_file() and path.stat().st_mtime >= workflow_start_time]
+                    outputs = []
+                    for path in files:
+                        p = Path(path)
+                        stem = p.stem.split("_")[-1] if "_" in p.stem else p.stem
+                        outputs.append({"stem": stem, "path": path})
                 emit("task_done", {
                     "files": files,
                     "outputs": outputs,

--- a/python/worker_workflows.py
+++ b/python/worker_workflows.py
@@ -211,6 +211,7 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
 
     failed = False
     succeeded_task_ids: set[str] = set()
+    failed_task_ids: set[str] = set()
     try:
         graph_workflow = is_graph_workflow_definition(payload.get("workflow"))
         output_root = Path(output_dir)
@@ -234,6 +235,7 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
                     )
                 except Exception as exc:
                     failed = True
+                    failed_task_ids.add(task_id)
                     emit_error("WORKFLOW_RUN_FAILED", str(exc), traceback.format_exc(), task_id=task_id)
                     continue
                 emit("task_stage", {"stage": "writing_output", "message": "Collecting workflow outputs", "progress": 92}, task_id=task_id)
@@ -273,6 +275,7 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
                 break
             if not completed:
                 failed = True
+                failed_task_ids.add(task_id)
                 emit_error(
                     "WORKFLOW_RUN_FAILED",
                     "Unable to run workflow with the installed pymss package.",
@@ -283,7 +286,7 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
     except Exception as exc:
         detail = traceback.format_exc()
         for item in batch_tasks:
-            if item["taskId"] not in succeeded_task_ids:
+            if item["taskId"] not in succeeded_task_ids and item["taskId"] not in failed_task_ids:
                 emit_error("WORKFLOW_RUN_FAILED", str(exc), detail, task_id=item["taskId"])
         return 1
 

--- a/python/worker_workflows.py
+++ b/python/worker_workflows.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 import tempfile

--- a/src-tauri/src/commands/app_cmd.rs
+++ b/src-tauri/src/commands/app_cmd.rs
@@ -271,6 +271,22 @@ fn safe_file_name(value: &str) -> String {
     }
 }
 
+fn percent_encode_query(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len() * 3);
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => {
+                encoded.push('%');
+                encoded.push_str(&format!("{:02X}", byte));
+            }
+        }
+    }
+    encoded
+}
+
 fn editor_project_dir(app: &AppHandle, project_id: &str) -> AppResult<PathBuf> {
     Ok(editor_projects_root(app)?.join(safe_file_name(project_id)))
 }
@@ -519,7 +535,10 @@ pub async fn open_workflow_node_editor_window(app: AppHandle, payload: Value) ->
             "index.html#/workflow-node-editor".to_string()
         }
     } else {
-        format!("index.html#/workflow-node-editor?workflowId={}", workflow_id)
+        format!(
+            "index.html#/workflow-node-editor?workflowId={}",
+            percent_encode_query(&workflow_id)
+        )
     };
     WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(url.into()))
         .title("Pymss Studio Workflow Node Editor")

--- a/src-tauri/src/commands/app_cmd.rs
+++ b/src-tauri/src/commands/app_cmd.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tauri::webview::PageLoadEvent;
-use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Emitter, State, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_dialog::DialogExt;
 
 #[cfg(windows)]
@@ -444,18 +444,9 @@ fn write_editor_project(app: &AppHandle, project: &Value) -> AppResult<Value> {
 
 #[tauri::command]
 pub async fn close_current_window(window: tauri::WebviewWindow) -> AppResult<()> {
-    let label = window.label().to_string();
-    let app_handle = window.app_handle().clone();
     window
         .destroy()
         .map_err(|error| AppError::Worker(error.to_string()))?;
-    if label.starts_with("workflow-node-editor") {
-        let _ = app_handle.emit_to(
-            "main",
-            "pymss://workflow-node-editor-closed",
-            serde_json::json!({ "label": label }),
-        );
-    }
     Ok(())
 }
 

--- a/src-tauri/src/commands/app_cmd.rs
+++ b/src-tauri/src/commands/app_cmd.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tauri::webview::PageLoadEvent;
-use tauri::{AppHandle, Emitter, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_dialog::DialogExt;
 
 #[cfg(windows)]

--- a/src-tauri/src/python/worker.rs
+++ b/src-tauri/src/python/worker.rs
@@ -456,7 +456,15 @@ pub fn run_worker_with_payload(
         return Err(err);
     }
 
-    let status = child.wait()?;
+    let status = match child.wait() {
+        Ok(status) => status,
+        Err(error) => {
+            if let Some(path) = payload_file.as_ref() {
+                let _ = std::fs::remove_file(path);
+            }
+            return Err(error.into());
+        }
+    };
     if let Some(handle) = stderr_handle {
         let _ = handle.join();
     }
@@ -524,17 +532,15 @@ pub fn spawn_worker_background(
         .ok_or_else(|| AppError::Worker("missing worker stdout".into()))?;
     let stderr = child.stderr.take();
     let stderr_app = app.clone();
-    let stderr_task_ids = registered_task_ids.clone();
+    let stderr_task_id = task_id.clone();
     #[cfg(debug_assertions)]
     let stderr_command = command_name.clone();
     let stderr_handle = stderr.map(|stderr| {
         std::thread::spawn(move || {
             read_lossy_lines(stderr, |line| {
-                for stderr_task_id in &stderr_task_ids {
-                    #[cfg(debug_assertions)]
-                    debug_log_worker_stderr(&stderr_command, Some(stderr_task_id), &line);
-                    emit_task_log(&stderr_app, stderr_task_id, "warning", line.clone());
-                }
+                #[cfg(debug_assertions)]
+                debug_log_worker_stderr(&stderr_command, Some(&stderr_task_id), &line);
+                emit_task_log(&stderr_app, &stderr_task_id, "warning", line.clone());
             });
         })
     });
@@ -596,23 +602,18 @@ pub fn spawn_worker_background(
             .cloned()
             .collect::<Vec<_>>();
         if !missing_terminal_task_ids.is_empty() {
-            match exit_status {
+            let message = match exit_status {
                 Some(status) if !status.success() => {
-                    emit_task_error_to_all(
-                        &app,
-                        &missing_terminal_task_ids,
-                        format!("worker exited with {status}"),
-                    );
+                    format!("worker exited with {status}")
                 }
                 None => {
-                    emit_task_error_to_all(
-                        &app,
-                        &missing_terminal_task_ids,
-                        "worker exited unexpectedly".to_string(),
-                    );
+                    "worker exited unexpectedly".to_string()
                 }
-                _ => {}
-            }
+                _ => {
+                    "worker exited without reporting results".to_string()
+                }
+            };
+            emit_task_error_to_all(&app, &missing_terminal_task_ids, message);
         }
         if let Some(handle) = stderr_handle {
             let _ = handle.join();

--- a/src-tauri/src/python/worker.rs
+++ b/src-tauri/src/python/worker.rs
@@ -382,7 +382,15 @@ pub fn run_worker_with_payload(
         None => None,
     };
     let mut cmd = build_worker_command(app, command, payload_file.as_ref())?;
-    let mut child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
+    let mut child = match cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            if let Some(path) = payload_file.as_ref() {
+                let _ = std::fs::remove_file(path);
+            }
+            return Err(error.into());
+        }
+    };
 
     let stdout = child
         .stdout
@@ -503,7 +511,13 @@ pub fn spawn_worker_background(
     let command_name = command.to_string();
     let payload_file = make_payload_file(command, Some(&task_id), payload)?;
     let mut cmd = build_worker_command(&app, command, Some(&payload_file))?;
-    let mut child: Child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
+    let mut child: Child = match cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            let _ = std::fs::remove_file(&payload_file);
+            return Err(error.into());
+        }
+    };
     let stdout = child
         .stdout
         .take()


### PR DESCRIPTION
## Summary

This PR fixes 14 bugs across the Python worker and Rust backend, covering batch error handling, process lifecycle safety, and audio export correctness.

## Bug Fixes

### Batch Error Handling (Critical)
- **cmd_infer_batch NameError on _prepare_separator() failure** -- succeeded_task_ids and failed dicts were declared inside try, causing NameError in except when _prepare_separator() threw before they existed. Moved declarations before the try block.
- **Stale task IDs in batch error emission** -- Failed tasks were added to failed dict only on except, but failed_task_ids was not deduplicated, causing duplicate error payloads. Added failed_task_ids set dedup.
- **failed_task_ids missing from cmd_infer_workflow_batch** -- The outer except handler emitted failed_task_ids: [] instead of the actual failed task IDs. Added dedup collection.

### Process Lifecycle
- **Zombie workflow processes** -- _run_workflow_cli spawned Timer-based watchdogs but never called process.wait(), leaving zombie processes. Added process.wait(timeout=5) in both _terminate_process and the finally block.
- **Payload file leak on spawn failure** -- run_worker_with_payload wrote temp payload files but never cleaned them up when child.wait() failed. Added explicit match on child.wait() result with cleanup.
- **Stuck tasks on clean exit** -- When spawn_worker_background exited with status 0, tasks with no terminal events stayed stuck forever. Added a sweep that emits errors for any remaining tasks on clean exit.
- **Stderr N-times duplication** -- Every stderr line was emitted for all active tasks, causing N duplicate messages in a batch of N. Now emits only for the primary task.

### Audio Export
- **cmd_export_editor_mix silent mute on None volume** -- volume = params.get("volume") or 0 treated both None and 0.0 as muted. Fixed to use explicit None check so 0.0 is respected while None defaults to 1.0. Same fix applied to pan.

### URL Encoding
- **Workflow node editor URL** -- _write_workflow_definition did not percent-encode the cwd parameter, breaking paths with spaces. Added inline percent_encode_query().

### Code Quality
- Unused imports removed (worker_audio in worker_infer.py, os in worker_workflows.py).
- .gitignore updated (src-tauri/gen/, pnpm-workspace.yaml, run-dev.bat).

## Testing
- cargo check: 0 errors, 0 warnings
- All 8 Python files pass py_compile
- Worker functional test: health, env_info, list_models all return valid JSON
- Full import audit across all files: no unused, missing, or fragile conditional imports
