### PR TITLE
fix(worker): add CUDA memory purge and unify separator teardown

### DIFF
--- a/python/worker_graph_workflows.py
+++ b/python/worker_graph_workflows.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import numpy as np
 
-from worker_infer import JsonLogHandler, _prepare_separator, _safe_filename_part, apply_output_naming, normalize_audio_params, resolve_pymss_output_dir
+from worker_infer import JsonLogHandler, _close_separator, _prepare_separator, _purge_cuda, _safe_filename_part, apply_output_naming, normalize_audio_params, resolve_pymss_output_dir
 from worker_protocol import emit
 
 
@@ -427,18 +427,23 @@ def _execute_separate_node(
             task_id=task_id,
         )
 
-    separator = _prepare_separator(
-        payload={
-            **payload,
-            "model": model_name,
-            "selectedStems": stems,
-            "inferenceParams": inference_params,
-            "output": payload.get("output") or "results",
-        },
-        task_id=task_id,
-        progress_callback=emit_node_progress,
-        logger=logger,
-    )
+    _purge_cuda()
+    try:
+        separator = _prepare_separator(
+            payload={
+                **payload,
+                "model": model_name,
+                "selectedStems": stems,
+                "inferenceParams": inference_params,
+                "output": payload.get("output") or "results",
+            },
+            task_id=task_id,
+            progress_callback=emit_node_progress,
+            logger=logger,
+        )
+    except Exception:
+        _purge_cuda()
+        raise
     try:
         sample_rate = int(separator.config.audio.get("sample_rate", source.sample_rate))
         from pymss.workflow import _ensure_sample_rate
@@ -458,13 +463,7 @@ def _execute_separate_node(
             )
         return selected
     finally:
-        close = getattr(separator, "close", None)
-        if callable(close):
-            close()
-        else:
-            cleanup = getattr(separator, "del_cache", None)
-            if callable(cleanup):
-                cleanup()
+        _close_separator(separator)
 
 
 def _resolve_chain_label(

--- a/python/worker_infer.py
+++ b/python/worker_infer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import os
 import re
 import traceback
@@ -265,6 +266,18 @@ def _close_separator(separator: Any) -> None:
             separator.del_cache()
         except Exception:
             pass
+    _purge_cuda()
+
+def _purge_cuda() -> None:
+    try:
+        gc.collect()
+        import torch
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        torch.backends.cudnn.benchmark = False
+    except Exception:
+        pass
+
 
 def _normalize_output_dir(value: Any) -> str:
     default_output_dir = os.environ.get("PYMSS_STUDIO_DEFAULT_OUTPUT_DIR")
@@ -927,15 +940,4 @@ def cmd_infer(payload: dict[str, Any]) -> int:
                 logger.removeHandler(log_handler)
             except Exception:
                 pass
-        if separator is not None:
-            close = getattr(separator, "close", None)
-            if callable(close):
-                try:
-                    close()
-                except Exception:
-                    pass
-            else:
-                try:
-                    separator.del_cache()
-                except Exception:
-                    pass
+        _close_separator(separator)


### PR DESCRIPTION
Supersedes #35.

> Merge note: worker_infer.py is also touched by #47, and worker_graph_workflows.py is also touched by #48. Both branch off upstream/main independently — merging one first may require a quick rebase of the others (the changes don't overlap at the line level).

GPU memory accumulates across consecutive CUDA separations, causing OOM on small-VRAM GPUs.

## Changes

**`python/worker_infer.py`**
- Add `import gc` and `_purge_cuda()` — runs `gc.collect()`, `torch.cuda.synchronize()`, `torch.cuda.empty_cache()`, resets `torch.backends.cudnn.benchmark`. Wrapped in try/except for CPU-only safety
- `_close_separator()`: call `_purge_cuda()` after closing
- `cmd_infer()` finally: replace inline close/del_cache with `_close_separator(separator)`

**`python/worker_graph_workflows.py`**
- Import `_close_separator`, `_purge_cuda`
- `_execute_separate_node()`: purge before creating separator, wrap `_prepare_separator()` in try/except (re-running `_purge_cuda()` in the except before re-raising), use `_close_separator()` in finally

## Notes

- `_purge_cuda()` resets `torch.backends.cudnn.benchmark` to its PyTorch default (`False`) defensively — the base code never sets it, but the pymss library can enable it internally (it sets `torch.backends.cudnn.benchmark = True` when creating a separator), and leaving it enabled adds an autotuning overhead to the next separation.
