### PR TITLE
fix: add audio export encoding and workflow run hardening

### DIFF
--- a/python/worker_audio.py
+++ b/python/worker_audio.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import subprocess
+import tempfile
 import traceback
 from pathlib import Path
 from typing import Any
@@ -134,8 +136,9 @@ def _apply_stereo_pan(audio: Any, pan: float) -> Any:
     if audio.shape[0] == 1:
         audio = np.repeat(audio, 2, axis=0)
 
-    left_gain = 1.0 if normalized <= 0 else 1.0 - normalized
-    right_gain = 1.0 if normalized >= 0 else 1.0 + normalized
+    angle = (normalized + 1.0) / 2.0
+    left_gain = math.cos(angle * math.pi / 2.0)
+    right_gain = math.sin(angle * math.pi / 2.0)
 
     output = audio.copy()
     output[0] *= left_gain
@@ -161,7 +164,7 @@ def cmd_waveform_peaks(payload: dict[str, Any]) -> int:
     path = Path(path_value)
     resolution = int(payload.get("resolution") or 1400)
     resolution = max(80, min(12000, resolution))
-    cache_dir = Path(payload.get("cacheDir") or path.parent / ".pymss-peaks")
+    cache_dir = Path(payload.get("cacheDir") or path.parent / ".pymss-peaks").resolve()
     cache_dir.mkdir(parents=True, exist_ok=True)
     cache_key = hashlib.sha1(str(path.resolve()).encode("utf-8", errors="replace")).hexdigest()[:16]
     cache_name = f"{path.stem}_{cache_key}_{resolution}_v2.json"
@@ -307,8 +310,10 @@ def cmd_export_editor_mix(payload: dict[str, Any]) -> int:
             if has_solo and not track.get("solo"):
                 continue
 
-            track_volume = float(track.get("volume", 1.0) or 0)
-            track_pan = float(track.get("pan", 0.0) or 0.0)
+            volume = track.get("volume")
+            track_volume = float(volume) if volume is not None else 1.0
+            pan = track.get("pan")
+            track_pan = float(pan) if pan is not None else 0.0
             if track_volume <= 0:
                 continue
 
@@ -337,7 +342,8 @@ def cmd_export_editor_mix(payload: dict[str, Any]) -> int:
                     continue
 
                 segment = audio[:, offset:offset + duration_samples].copy()
-                volume = track_volume * float(clip.get("volume", 1.0) or 0)
+                raw_clip_volume = clip.get("volume")
+                volume = track_volume * (float(raw_clip_volume) if raw_clip_volume is not None else 1.0)
                 if volume <= 0:
                     continue
                 segment *= volume
@@ -368,10 +374,12 @@ def cmd_export_editor_mix(payload: dict[str, Any]) -> int:
                 segment = np.concatenate([segment, pad], axis=0)
             mix[:, start:start + segment.shape[-1]] += segment[:channels]
 
-        master_volume = float(project.get("masterVolume", 1.0) or 0)
+        raw_master_volume = project.get("masterVolume")
+        master_volume = float(raw_master_volume) if raw_master_volume is not None else 1.0
         if master_volume != 1.0:
             mix *= master_volume
-        master_pan = float(project.get("masterPan", 0.0) or 0.0)
+        raw_master_pan = project.get("masterPan")
+        master_pan = float(raw_master_pan) if raw_master_pan is not None else 0.0
         mix = _apply_stereo_pan(mix, master_pan)
 
         peak = float(np.max(np.abs(mix))) if mix.size else 0.0
@@ -389,15 +397,33 @@ def cmd_export_editor_mix(payload: dict[str, Any]) -> int:
             requested = str(audio_params.get("flac_bit_depth") or audio_params.get("flacBitDepth") or "PCM_24").upper()
             subtype = requested if requested in {"PCM_16", "PCM_24"} else "PCM_24"
         elif output_format in {"mp3", "m4a"}:
-            output_path = output_path.with_suffix(".wav")
-            output_format = "wav"
-            requested = str(audio_params.get("wav_bit_depth") or audio_params.get("wavBitDepth") or "PCM_24").upper()
-            subtype = requested if requested in {"PCM_16", "PCM_24", "FLOAT"} else "PCM_24"
+            if output_format == "mp3":
+                bit_rate = str(audio_params.get("mp3_bit_rate") or audio_params.get("mp3BitRate") or "320k")
+            else:
+                bit_rate = str(audio_params.get("m4a_bit_rate") or audio_params.get("m4aBitRate") or "512k")
 
         write_kwargs: dict[str, Any] = {}
         if subtype:
             write_kwargs["subtype"] = subtype
-        sf.write(str(output_path), mix.T, target_rate, **write_kwargs)
+
+        if output_format in {"mp3", "m4a"}:
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                tmp_wav = tmp.name
+            try:
+                sf.write(tmp_wav, mix.T, target_rate, **write_kwargs)
+                codec = ["-codec:a", "libmp3lame", "-b:a", bit_rate] if output_format == "mp3" else ["-codec:a", "aac", "-b:a", bit_rate]
+                cmd = ["ffmpeg", "-y", "-i", tmp_wav] + codec + [str(output_path)]
+                proc = subprocess.run(cmd, capture_output=True, timeout=300)
+                if proc.returncode != 0:
+                    stderr_msg = proc.stderr.decode("utf-8", errors="replace") if proc.stderr else ""
+                    raise RuntimeError(f"ffmpeg encoding failed (exit {proc.returncode}): {stderr_msg[:500]}")
+            finally:
+                try:
+                    Path(tmp_wav).unlink(missing_ok=True)
+                except Exception:
+                    pass
+        else:
+            sf.write(str(output_path), mix.T, target_rate, **write_kwargs)
         emit("editor_mix_exported", {
             "path": str(output_path),
             "duration": total_samples / target_rate,

--- a/python/worker_graph_workflows.py
+++ b/python/worker_graph_workflows.py
@@ -440,7 +440,8 @@ def _execute_separate_node(
         logger=logger,
     )
     try:
-        sample_rate = int(separator.config.audio.get("sample_rate", source.sample_rate))
+        audio_config = getattr(getattr(separator, "config", {}), "audio", {}) or {}
+        sample_rate = int(audio_config.get("sample_rate", source.sample_rate))
         from pymss.workflow import _ensure_sample_rate
 
         model_audio = _to_model_audio(_ensure_sample_rate(_normalize_artifact_audio(source.audio), source.sample_rate, sample_rate))

--- a/python/worker_models.py
+++ b/python/worker_models.py
@@ -349,7 +349,7 @@ def _derive_overlap_size_from_num_overlap(chunk_size: Any, num_overlap: Any) -> 
     if chunk_value <= 0 or overlap_count <= 0:
         return None
     if overlap_count == 1:
-        return 0
+        return None
     step = int(chunk_value // overlap_count)
     overlap_size = int(chunk_value - step)
     if overlap_size < 0 or overlap_size >= chunk_value:
@@ -1009,7 +1009,7 @@ def _path_size(path: Path) -> int:
         if path.is_file():
             return int(path.stat().st_size)
         if path.is_dir():
-            return sum(_path_size(child) for child in path.rglob("*") if child.is_file())
+            return sum(int(f.stat().st_size) for f in path.rglob("*") if f.is_file())
     except Exception:
         return 0
     return 0

--- a/python/worker_protocol.py
+++ b/python/worker_protocol.py
@@ -116,8 +116,12 @@ def load_payload(payload_arg: str | None) -> dict[str, Any]:
         return {}
     path = Path(payload_arg)
     if path.is_file():
-        return json.loads(path.read_text(encoding="utf-8"))
-    return json.loads(payload_arg)
+        result = json.loads(path.read_text(encoding="utf-8"))
+    else:
+        result = json.loads(payload_arg)
+    if not isinstance(result, dict):
+        raise ValueError(f"Payload must be a JSON object, got {type(result).__name__}")
+    return result
 
 
 def _as_int(value: Any) -> int | None:

--- a/python/worker_workflows.py
+++ b/python/worker_workflows.py
@@ -4,18 +4,14 @@ import json
 import subprocess
 import sys
 import tempfile
+import threading
 import traceback
 from pathlib import Path
 from typing import Any
 
 from worker_graph_workflows import is_graph_workflow_definition, run_graph_workflow_task
-from worker_infer import _normalize_output_layout, _resolve_separator_device, apply_output_naming, collect_changed_files, collect_outputs, snapshot_output_files
+from worker_infer import _normalize_output_dir, _normalize_output_layout, _resolve_separator_device, apply_output_naming, collect_changed_files, collect_outputs, snapshot_output_files
 from worker_protocol import emit, emit_error
-
-
-def _normalize_output_dir(value: Any) -> str:
-    text = str(value or "").strip()
-    return text or "results"
 
 
 def _write_workflow_definition(payload: dict[str, Any], task_id: str) -> Path:
@@ -79,6 +75,8 @@ def _candidate_commands(workflow_path: Path, input_path: str, output_dir: str, p
         str(audio_params.get("m4a_bit_rate") or "512k"),
         "--m4a-codec",
         str(audio_params.get("m4a_codec") or "aac"),
+        "--m4a-aac-at-quality",
+        str(audio_params.get("m4a_aac_at_quality") or 2),
     ]
     model_dir = str(payload.get("modelDir") or "").strip()
     if model_dir:
@@ -107,6 +105,17 @@ def _candidate_commands(workflow_path: Path, input_path: str, output_dir: str, p
     ]
 
 
+def _terminate_process(process: subprocess.Popen[bytes], task_id: str) -> None:
+    try:
+        process.kill()
+    except Exception as exc:
+        emit("task_log", {"level": "warning", "message": f"Failed to terminate workflow process for {task_id}: {exc}"}, task_id=task_id)
+    try:
+        process.wait(timeout=5)
+    except Exception:
+        pass
+
+
 def _run_workflow_cli(command: list[str], task_id: str) -> tuple[int, str]:
     emit("task_log", {"level": "info", "message": " ".join(command)}, task_id=task_id)
     process = subprocess.Popen(
@@ -118,21 +127,31 @@ def _run_workflow_cli(command: list[str], task_id: str) -> tuple[int, str]:
         errors="replace",
     )
     lines: list[str] = []
-    assert process.stdout is not None
-    for line in process.stdout:
-        text = line.rstrip()
-        if not text:
-            continue
-        lines.append(text)
-        try:
-            event = json.loads(text)
-            if isinstance(event, dict) and isinstance(event.get("type"), str):
-                emit(event["type"], event.get("payload") if isinstance(event.get("payload"), dict) else {}, task_id=task_id)
+    if process.stdout is None:
+        raise RuntimeError("Workflow process stdout is not available")
+    timer = threading.Timer(6 * 3600, _terminate_process, args=(process, task_id))
+    timer.start()
+    try:
+        for line in process.stdout:
+            text = line.rstrip()
+            if not text:
                 continue
+            lines.append(text)
+            try:
+                event = json.loads(text)
+                if isinstance(event, dict) and isinstance(event.get("type"), str):
+                    emit(event["type"], event.get("payload") if isinstance(event.get("payload"), dict) else {}, task_id=task_id)
+                    continue
+            except Exception:
+                pass
+            emit("task_log", {"level": "info", "message": text}, task_id=task_id)
+        return process.wait(), "\n".join(lines[-40:])
+    finally:
+        timer.cancel()
+        try:
+            process.wait(timeout=5)
         except Exception:
             pass
-        emit("task_log", {"level": "info", "message": text}, task_id=task_id)
-    return process.wait(), "\n".join(lines[-40:])
 
 
 def _workflow_task_output_dir(output_dir: str, input_path: str, output_layout: str) -> Path:
@@ -205,6 +224,8 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
         return _emit_workflow_batch_error(raw_tasks, root_task_id, "WORKFLOW_MISSING", "Workflow definition is required")
 
     failed = False
+    succeeded_task_ids: set[str] = set()
+    failed_task_ids: set[str] = set()
     try:
         graph_workflow = is_graph_workflow_definition(payload.get("workflow"))
         output_root = Path(output_dir)
@@ -227,10 +248,12 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
                     )
                 except Exception as exc:
                     failed = True
+                    failed_task_ids.add(task_id)
                     emit_error("WORKFLOW_RUN_FAILED", str(exc), traceback.format_exc(), task_id=task_id)
                     continue
                 emit("task_stage", {"stage": "writing_output", "message": "Collecting workflow outputs", "progress": 92}, task_id=task_id)
                 emit("task_done", result, task_id=task_id)
+                succeeded_task_ids.add(task_id)
                 continue
             failures: list[str] = []
             completed = False
@@ -263,10 +286,12 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
                     "outputDir": str(task_output_dir.resolve()),
                     "outputFormat": output_format,
                 }, task_id=task_id)
+                succeeded_task_ids.add(task_id)
                 completed = True
                 break
             if not completed:
                 failed = True
+                failed_task_ids.add(task_id)
                 emit_error(
                     "WORKFLOW_RUN_FAILED",
                     "Unable to run workflow with the installed pymss package.",
@@ -277,7 +302,8 @@ def cmd_infer_workflow_batch(payload: dict[str, Any]) -> int:
     except Exception as exc:
         detail = traceback.format_exc()
         for item in batch_tasks:
-            emit_error("WORKFLOW_RUN_FAILED", str(exc), detail, task_id=item["taskId"])
+            if item["taskId"] not in succeeded_task_ids and item["taskId"] not in failed_task_ids:
+                emit_error("WORKFLOW_RUN_FAILED", str(exc), detail, task_id=item["taskId"])
         return 1
 
 


### PR DESCRIPTION
Supersedes #35.

> Merge note: `worker_graph_workflows.py` is also touched by #46. Both branch off upstream/main independently — merging one first may require a quick rebase of the other (changes don't overlap at the line level).

Fixes MP3/M4A export falling back to WAV, corrects stereo panning, hardens null handling, and adds subprocess safety to workflow execution.

## Changes

**`python/worker_audio.py`**
- `_apply_stereo_pan()`: replace linear gain ramps with equal-power panning (`cos`/`sin` gain curves) — matches the frontend panning math (applied to the frontend in #49); the pre-existing `abs(normalized) <= 1e-6` early return keeps center panning at full level (with linear gains it was a no-op)
- `cmd_waveform_peaks()`: add `.resolve()` to `cache_dir`
- `cmd_export_editor_mix()`: replace `float(x or 0)` with explicit null-safe checks for track/clip/master volume and pan — a null volume now falls back to the default (`1.0`) instead of being coerced to `0` (muting the track); a null pan keeps its `0.0` default, and an explicit `0` remains a valid value
- `cmd_export_editor_mix()`: route MP3/M4A export through ffmpeg (`libmp3lame` for MP3, `aac` for M4A) via subprocess instead of silently falling back to WAV

**`python/worker_models.py`**
- `_derive_overlap_size_from_num_overlap()`: return `None` instead of `0` when `overlap_count == 1`
- `_path_size()`: replace recursive call with a flat sum over files

**`python/worker_protocol.py`**
- `load_payload()`: raise `ValueError` if the parsed payload is not a dict

**`python/worker_workflows.py`**
- Add `_terminate_process()`: subprocess kill + `wait(timeout=5)`
- `_run_workflow_cli()`: replace `assert process.stdout is not None` with `raise RuntimeError(...)`; add a 6-hour `threading.Timer` safety kill via `_terminate_process()` with cleanup in `finally`
- `_candidate_commands()`: add `--m4a-aac-at-quality` parameter support
- `cmd_infer_workflow_batch()`: add `succeeded_task_ids`/`failed_task_ids` tracking to prevent duplicate error emissions
- Remove local `_normalize_output_dir()` definition — import from `worker_infer` instead (this also changes semantics: the worker_infer version consults `PYMSS_STUDIO_DEFAULT_OUTPUT_DIR` and resolves relative output paths against it)

**`python/worker_graph_workflows.py`**
- `_execute_separate_node()`: replace `separator.config.audio.get(...)` with `getattr(getattr(separator, "config", {}), "audio", {}) or {}` — if `config` or `audio` is missing, this silently falls back to `{}` (using default values) instead of raising

## Notes

- The `m4a_codec` setting (including `"aac_at"`, added in #47) isn't read on this specific export path (`cmd_export_editor_mix()`) — M4A always uses `aac` here regardless of the setting. `_prepare_separator()` does pass `m4a_codec` through on the `cmd_infer`/`cmd_infer_batch` paths, where whether `aac_at` works depends on the local PyAV/FFmpeg build (as noted in #47).
- ffmpeg encoding runs with a 5-minute `timeout=300` — longer encodes fail with an explicit error.
- For MP3/M4A the intermediate WAV is written with soundfile's default subtype (bit depth, `PCM_16`) — `subtype` is left unset on this path, whereas the old WAV fallback used `wav_bit_depth` (default `PCM_24`).
- ffmpeg is bundled in release builds on both platforms and prepended to the worker's PATH — no new runtime dependency. On Windows, `release-windows.yml` stages `bin/ffmpeg.exe` into the portable directory (the build throws if the downloaded `ffmpeg.exe` is missing); on macOS, `scripts/prepare-macos-bundled-tools.sh` copies the Homebrew-installed `ffmpeg`/`ffprobe` into `resources/bin/` and relinks their dylibs for app-local execution, and the macOS build verifies the bundled tools in CI with `shutil.which('ffmpeg')`. Encoding failures now surface as an explicit error instead of silently falling back to WAV. The only path that can miss ffmpeg is development mode (`pnpm tauri dev`), which has no bundle and relies on a system-installed ffmpeg.
- The 6-hour timer kill doesn't produce a distinct "timeout" message — it surfaces as a generic `WORKFLOW_RUN_FAILED`. The 6-hour threshold is a conservative upper bound, not tied to a specific requirement.
- `process.wait()` runs in the `finally` cleanup on every exit and additionally inside `_terminate_process()` on a timer-triggered kill — both on top of the loop's own `return process.wait()` — repeated `wait()` calls are harmless.
- `_derive_overlap_size_from_num_overlap()` returns `None` instead of `0` when `overlap_count == 1`, so `overlap_size` is left unset and pymss's default applies. This is consistent with the `overlap_size=0` semantics — both treat "no overlap" as valid rather than an invalid input.
