### PR TITLE
fix: harden backend failure handling and frontend panning/UI fixes

### DIFF
--- a/src-tauri/src/commands/app_cmd.rs
+++ b/src-tauri/src/commands/app_cmd.rs
@@ -1012,21 +1012,28 @@ fn write_editor_project(app: &AppHandle, project: &Value) -> AppResult<Value> {
     Ok(project.clone())
 }
 
+fn percent_encode_query(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len() * 3);
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => {
+                encoded.push('%');
+                encoded.push_str(&format!("{:02X}", byte));
+            }
+        }
+    }
+    encoded
+}
+
 
 #[tauri::command]
 pub async fn close_current_window(window: tauri::WebviewWindow) -> AppResult<()> {
-    let label = window.label().to_string();
-    let app_handle = window.app_handle().clone();
     window
         .destroy()
         .map_err(|error| AppError::Worker(error.to_string()))?;
-    if label.starts_with("workflow-node-editor") {
-        let _ = app_handle.emit_to(
-            "main",
-            "pymss://workflow-node-editor-closed",
-            serde_json::json!({ "label": label }),
-        );
-    }
     Ok(())
 }
 
@@ -1099,7 +1106,7 @@ pub async fn open_workflow_node_editor_window(app: AppHandle, payload: Value) ->
             "index.html#/workflow-node-editor".to_string()
         }
     } else {
-        format!("index.html#/workflow-node-editor?workflowId={}", workflow_id)
+        format!("index.html#/workflow-node-editor?workflowId={}", percent_encode_query(&workflow_id))
     };
     WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(url.into()))
         .title("Pymss Studio Workflow Node Editor")

--- a/src-tauri/src/python/worker.rs
+++ b/src-tauri/src/python/worker.rs
@@ -746,7 +746,15 @@ pub fn run_worker_with_payload(
     let mut cmd = build_worker_command(app, command, payload_file.as_ref())?;
     let started_at = std::time::Instant::now();
     session_log::append(app, "INFO", "worker.spawn", vec![("command", command.to_string())]);
-    let mut child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
+    let mut child = match cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            if let Some(path) = payload_file.as_ref() {
+                let _ = std::fs::remove_file(path);
+            }
+            return Err(error.into());
+        }
+    };
 
     let stdout = child
         .stdout
@@ -807,7 +815,15 @@ pub fn run_worker_with_payload(
             }
         }
     });
-    let status = child.wait()?;
+    let status = match child.wait() {
+        Ok(status) => status,
+        Err(error) => {
+            if let Some(path) = payload_file.as_ref() {
+                let _ = std::fs::remove_file(path);
+            }
+            return Err(error.into());
+        }
+    };
     session_log::append(
         app,
         if status.success() { "INFO" } else { "ERROR" },
@@ -899,24 +915,28 @@ pub fn spawn_worker_background(
         "worker.spawn",
         vec![("command", command.to_string()), ("taskId", task_id.clone())],
     );
-    let mut child: Child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
+    let mut child: Child = match cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            let _ = std::fs::remove_file(&payload_file);
+            return Err(error.into());
+        }
+    };
     let stdout = child
         .stdout
         .take()
         .ok_or_else(|| AppError::Worker("missing worker stdout".into()))?;
     let stderr = child.stderr.take();
     let stderr_app = app.clone();
-    let stderr_task_ids = registered_task_ids.clone();
+    let stderr_task_id = task_id.clone();
     #[cfg(debug_assertions)]
     let stderr_command = command_name.clone();
     let stderr_handle = stderr.map(|stderr| {
         std::thread::spawn(move || {
             read_lossy_lines(stderr, |line| {
-                for stderr_task_id in &stderr_task_ids {
-                    #[cfg(debug_assertions)]
-                    debug_log_worker_stderr(&stderr_command, Some(stderr_task_id), &line);
-                    emit_task_log(&stderr_app, stderr_task_id, "warning", line.clone());
-                }
+                #[cfg(debug_assertions)]
+                debug_log_worker_stderr(&stderr_command, Some(&stderr_task_id), &line);
+                emit_task_log(&stderr_app, &stderr_task_id, "warning", line.clone());
             });
         })
     });
@@ -1000,23 +1020,18 @@ pub fn spawn_worker_background(
             .cloned()
             .collect::<Vec<_>>();
         if !missing_terminal_task_ids.is_empty() {
-            match exit_status {
+            let message = match exit_status {
                 Some(status) if !status.success() => {
-                    emit_task_error_to_all(
-                        &app,
-                        &missing_terminal_task_ids,
-                        format!("worker exited with {status}"),
-                    );
+                    format!("worker exited with {status}")
                 }
                 None => {
-                    emit_task_error_to_all(
-                        &app,
-                        &missing_terminal_task_ids,
-                        "worker exited unexpectedly".to_string(),
-                    );
+                    "worker exited unexpectedly".to_string()
                 }
-                _ => {}
-            }
+                _ => {
+                    "worker exited without reporting results".to_string()
+                }
+            };
+            emit_task_error_to_all(&app, &missing_terminal_task_ids, message);
         }
         if let Some(handle) = stderr_handle {
             let _ = handle.join();

--- a/src/composables/useEditorPlayback.ts
+++ b/src/composables/useEditorPlayback.ts
@@ -166,9 +166,11 @@ export function useEditorPlayback(options: PlaybackOptions) {
 
   function stereoGainForPan(pan: number) {
     const normalized = clamp(Number(pan || 0), -1, 1)
+    if (Math.abs(normalized) <= 1e-6) return { left: 1, right: 1 }
+    const angle = (normalized + 1.0) / 2.0
     return {
-      left: normalized <= 0 ? 1 : 1 - normalized,
-      right: normalized >= 0 ? 1 : 1 + normalized,
+      left: Math.cos(angle * Math.PI / 2.0),
+      right: Math.sin(angle * Math.PI / 2.0),
     }
   }
 

--- a/src/utils/workflowDefinition.ts
+++ b/src/utils/workflowDefinition.ts
@@ -683,7 +683,7 @@ export function getWorkflowStepDisplayId(index: number) {
 }
 
 export function safeWorkflowStemDir(stem: string) {
-  return stem.trim().replace(/[<>:"/\\|?*\x00-\x1f]+/g, '_') || stem
+  return stem.trim().replace(/[<>:"/\\|?*\x00-\x1f]+/g, '_') || 'stem'
 }
 
 export function buildWorkflowConsumedStemSet(steps: WorkflowStepDraft[]) {

--- a/src/views/SeparateView.vue
+++ b/src/views/SeparateView.vue
@@ -526,7 +526,9 @@ const modelCompactLine = computed(() => {
 const currentTaskFileName = computed(() => currentTask.value ? getFileName(currentTask.value.input) : '')
 const currentTaskOutputPath = computed(() => currentJob.value?.output || currentTask.value?.output || normalizedOutputDir.value)
 const currentTaskOutputSummary = computed(() => shortenMiddle(currentTaskOutputPath.value, 72))
-const currentTaskDuration = computed(() => currentTask.value ? taskDuration(currentTask.value) : '')
+const durationTick = ref(0)
+let durationInterval: ReturnType<typeof setInterval> | null = null
+const currentTaskDuration = computed(() => currentTask.value ? taskDuration(currentTask.value, durationTick.value || undefined) : '')
 
 function configuredStemOrder(item: SeparationTask) {
   if (item.runConfig?.outputNaming?.stemOrder?.length) return item.runConfig.outputNaming.stemOrder
@@ -1034,11 +1036,13 @@ function taskSubMessage(item: SeparationTask) {
   return normalizeProgressMessage(item.progressDetail || item.message)
 }
 
-function taskDuration(item: SeparationTask) {
-  const seconds = Math.max(0, Math.round((item.updatedAt - item.createdAt) / 1000))
-  if (seconds < 60) return `${seconds}s`
-  const minutes = Math.floor(seconds / 60)
-  const rest = seconds % 60
+function taskDuration(item: SeparationTask, now?: number) {
+  const terminal = ['done', 'failed', 'cancelled'].includes(item.status)
+  const end = terminal ? item.updatedAt : (now || Date.now())
+  const elapsed = Math.max(0, Math.round((end - item.createdAt) / 1000))
+  if (elapsed < 60) return `${elapsed}s`
+  const minutes = Math.floor(elapsed / 60)
+  const rest = elapsed % 60
   return `${minutes}m ${rest}s`
 }
 
@@ -1194,6 +1198,7 @@ watch(
 )
 
 onMounted(async () => {
+  durationInterval = setInterval(() => { durationTick.value = Date.now() }, 1000)
   if (import.meta.env.DEV && route.query.preview === 'results') {
     const previewJob = [...task.resultJobs].sort((a, b) => b.updatedAt - a.updatedAt)[0]
     if (previewJob) focusedSeparationJobId.value = previewJob.id
@@ -1222,6 +1227,7 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+  if (durationInterval) { clearInterval(durationInterval); durationInterval = null }
   if (unlistenDragDrop) unlistenDragDrop()
   finishInputPointerDrag()
   finishStemPointerDrag()


### PR DESCRIPTION
Supersedes #35.

Fixes URL encoding, payload cleanup, and worker exit handling on the Rust side; improves stereo panning balance and fixes a couple of UI bugs.

## Changes

**`src-tauri/src/commands/app_cmd.rs`**
- Add `percent_encode_query()`: URL-encodes `workflowId` query parameters
- `open_workflow_node_editor_window()`: apply `percent_encode_query()` to `workflow_id`
- `close_current_window()`: remove duplicate emit of `pymss://workflow-node-editor-closed` — the `Destroyed` window event handler already sends this event, so the command-side emit was redundant

**`src-tauri/src/python/worker.rs`**
- `run_worker_with_payload()`: clean up the payload file if `spawn()` or `wait()` fails
- `spawn_worker_background()`: same cleanup on spawn failure
- Stderr handling: scope to a single `task_id` instead of looping over all registered tasks
- Worker exit without a terminal event: previously silent, which could leave a task stuck as "running" in the UI indefinitely; now emits a typed error ("worker exited without reporting results") so the failure surfaces to the user

**`src/composables/useEditorPlayback.ts`**
- `stereoGainForPan()`: replace linear panning with equal-power panning (`Math.cos`/`Math.sin` gain curves) for a more natural playback preview balance; add an `abs(normalized) <= 1e-6` guard returning `{ left: 1, right: 1 }` so center panning keeps full level — mirrors the worker-side guard in `_apply_stereo_pan()`

**`src/utils/workflowDefinition.ts`**
- `safeWorkflowStemDir()`: replace `|| stem` with `|| 'stem'` — when the sanitized result is empty (e.g., empty or whitespace-only stem), `|| stem` falls back to the raw input, which can still be empty/whitespace; the literal `'stem'` guarantees a stable, usable directory name

**`src/views/SeparateView.vue`**
- Add a `durationTick` ref + `setInterval(1000)` for real-time task duration display
- `taskDuration()`: switch from `updatedAt`-based to `Date.now()`-based elapsed time — previously the displayed duration only updated when the task object itself was updated
- `onMounted` / `onBeforeUnmount`: start/clean up the interval

## Notes

- For single-task payloads this is behavior-preserving; for multi-task batch payloads it changes attribution — stderr goes only to the payload's primary `task_id`. Batch separation (`startSeparation`/`startWorkflowInference` in batch mode) sends multiple tasks per payload via `tasks[]`, so batch runs are affected. The backend API itself doesn't preclude multi-task payloads.
- The `Destroyed` window handler is confirmed to emit the same event; the old command-side emit is removed, so the event is now emitted from a single place (exact ordering vs. the previous emit is runtime-dependent).
- `percent_encode_query()` is currently applied only to `open_workflow_node_editor_window()`'s `workflowId`; no other query params are affected.
- `stdout.take()` failure (unexpected in practice — the pipe is always configured) isn't followed by payload file cleanup — same as the original code; besides the new `spawn()`/`wait()` failure cleanups, the pre-existing end-of-function cleanup still removes the file on the success/worker-error paths.
- `taskDuration()` uses `Date.now()` for every non-terminal state (`queued`, `preparing`, `validating_input`, `downloading_model`, `ensuring_model`, `loading_model`, `separating`, `writing_output`) — live count-up via the 1-second `durationTick` interval — and falls back to `updatedAt` for terminal states (`done`/`failed`/`cancelled`) so the elapsed time freezes at completion. This means a `queued` task's duration counts up from creation while it waits, not only once it starts running. For `failed` tasks specifically, `updatedAt` reflects the last progress update rather than the exact failure time, so the displayed duration can be marginally shorter than the actual run time.
