### PR TITLE
feat(a11y): 读屏软件支持(方案 C — 简化页 + 主界面全量可达)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,15 @@ GitHub releases may split files >2GB using `split` (workflow auto-handles). See 
 ## Testing
 
 No automated test suite currently. Verification is manual + CI smoke tests (env_info, list_models).
+
+## Accessibility maintenance
+
+The app has an a11y layer that must be preserved when touching UI. Key pieces:
+
+- `src/components/SrText.vue` — visually-hidden text for screen readers (labels icon-only buttons, adds context).
+- `src/composables/useLiveAnnouncer.ts` — singleton that writes to the polite/assertive `aria-live` regions mounted by `src/components/A11yProvider.vue` (which also mounts the skip-to-content link).
+- `src/composables/useFocusTrap.ts` — focus containment + Esc handling for custom `role="dialog"` overlays rendered outside `n-modal`.
+- `src/composables/useRovingTabindex.ts` — roving-tabindex arrow-key navigation for toolbars, tab lists, and track rows.
+- i18n `a11y.*` namespace — user-facing accessible strings (skip-link text, live announcements). Add new screen-reader strings here, not as hardcoded text in components.
+- `?` opens the keyboard shortcuts help (`src/components/ShortcutsHelpDialog.vue`, wired in `App.vue`). Keep the shortcut list in sync with `src/composables/useEditorShortcuts.ts`.
+

--- a/README.md
+++ b/README.md
@@ -242,3 +242,24 @@ Pymss Studio is licensed under the GNU Affero General Public License v3.0. See [
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for details on how to contribute to Pymss Studio.
+
+## Accessibility
+
+Pymss Studio ships with a screen-reader and keyboard accessibility layer that is
+available alongside the standard workspace:
+
+- **Simplified mode** — The `/simple` route (`#/simple`) renders a streamlined,
+  screen-reader-friendly view of the core separation workflow. It is the
+  recommended entry point for assistive-technology users who want a linear,
+  form-driven experience without the dense stem editor canvas.
+- **Keyboard shortcuts help** — Press <kbd>?</kbd> (Shift+/) anywhere outside a
+  text field to open the keyboard shortcuts reference dialog. The dialog lists
+  every editor and global shortcut, traps focus while open, and closes with
+  <kbd>Esc</kbd> or the Close button.
+- **Skip to content** — A "Skip to main content" link is the first focusable
+  element on every page. Tab into the app and activate it to jump straight to
+  the main region, bypassing the sidebar and title bar.
+- **Focus-visible indicators** — All interactive elements (links, buttons,
+  inputs, custom controls) show a visible keyboard focus ring via the global
+  `:focus-visible` style so keyboard users can always track where they are.
+

--- a/docs/plans/2025-08-25-screen-reader-support-design.md
+++ b/docs/plans/2025-08-25-screen-reader-support-design.md
@@ -1,0 +1,164 @@
+# Pymss Studio 读屏支持设计方案
+
+- **日期**: 2025-08-25
+- **状态**: 已确认,待实施
+- **方案**: C — 简化操作页 + 主界面全量可达(含画布可驱动)
+- **读屏矩阵**: NVDA + Windows 讲述器 + JAWS(试用版)
+- **波形策略**: 播放 + 口述时间码 + 轨道文本摘要(不做声学声化)
+
+---
+
+## 0. 背景与现状
+
+Pymss Studio 是 Tauri 桌面应用(Vue 3 + Naive UI + Rust 编排 Python worker),核心功能是音源分离。代码库**已有部分可达性地基**:
+
+- Naive UI 组件自带 ARIA;手写 `role="dialog"`/`aria-modal` 出现在 SeparateView×4、`CustomModelImportDialog`、`DownloadDetailModal`、`WorkflowRevisionConflictModal`
+- `EditorTransportBar` 已有 `sr-only` 类、`aria-pressed`、`aria-label`
+- `SeparateView` 已有 `role="listbox"`/`role="option"`/`aria-selected`
+- `useEditorShortcuts.ts` 已有一套编辑器全局键盘快捷键(播放/停止/跳转 ±1s/±5s/静音/独奏/缩放/撤销重做/保存)
+- i18n 双语(zh-CN / en),`tests/i18nKeys.test.ts` 校验两份键一致
+
+**主要缺口**:
+
+1. 画布部件 `EditorWaveform`(纯 `<canvas>`,无文本替代)和 `WorkflowNodeEditor`(5000 行 2D 空间图)对读屏完全不可达
+2. 自定义容器键盘不可操作(轨道行 `@mousedown` 选择、跳转靠鼠标坐标、资源拖拽仅鼠标)
+3. 进度/toast/播放态无 `aria-live` 播报
+4. 手写 `role="dialog"` 缺焦点陷阱与焦点回归
+5. 自定义控件(`.chip`/`.nav-item`/`.track-row`)无 `:focus-visible` 焦点环
+
+Tauri 用 WebView2(Chromium),MSAA/UIA 树自动暴露给读屏,**无需改 Rust 或 Python worker**。
+
+## 0.1 架构策略
+
+考虑过三条路:
+
+- **A. 复用 Naive UI a11y + 自建薄层原语 + 为画布加并行可访问 DOM**(推荐)
+- B. 自建全套 a11y 框架(焦点陷阱/树漫游/直播区全自研)
+- C. 引入 `focus-trap`、`aria-live` 等外部库
+
+选 **A**:已有地基可直接嫁接;Tauri WebView2 自动暴露 a11y 树;外部库与离线打包/体积不划算。两个画布部件的核心思路是**提供文本化等价界面**,而非让 2D 画布本身可键盘拖拽——这是 WAI-ARIA 对复杂空间控件的标准做法。
+
+## 0.2 简化页决策
+
+用户选 **方案 C(两者都要,最全)**:
+
+- **路径 1 — 简化操作页 `/simple`**:线性、语义化、表单驱动,覆盖分离 + 模型管理 + 结果。盲人用户日常走这条。
+- **路径 2 — 主界面全量可达**:所有原视图做到 ARIA 完整 + 键盘可操作 + 焦点管理 + 直播区;波形与工作流画布额外做成可驱动,供进阶盲人用户使用。
+
+两条路径共享同一套 stores(`task`/`model`/`settings`/`workflow`/`editor`)和原语层,不另起状态。
+
+---
+
+## 1. 原语层(新增,两条路径共用)
+
+| 文件 | 作用 |
+|---|---|
+| `src/components/A11yProvider.vue` | 挂 `aria-live` polite/assertive 双区、跳转链接目标、路由切换焦点迁移 |
+| `src/composables/useLiveAnnouncer.ts` | 单例播报器(进度/toast/播放态/时间码),节流策略(播放中默认每 1s) |
+| `src/composables/useFocusTrap.ts` | 手写 `role="dialog"` 块的陷阱 + 回归焦点 + Esc 关闭 |
+| `src/composables/useRovingTabindex.ts` | 混音器轨道行、工作流节点的漫游焦点 |
+| `src/components/SrText.vue` | 全局 `sr-only` 文本包装(把 `EditorTransportBar` 内联 `.sr-only` 提为全局) |
+
+## 2. 简化操作页 `/simple`(新增)
+
+**路由与入口**: `/simple` 路由;SideNav 底部 + 设置页 + 首启 Onboarding 三处放"简化操作模式"入口。**不自动跳转**(JS 检测读屏不可靠且涉隐私)。
+
+**布局**: 单列纵向,语义化 `<section>` + `<h1/h2>` 层级,纯表单控件,原生 `<audio controls>` 播放(读屏天然支持)。
+
+- **分离区**: `<select>` 模型 / `<select>` 工作流 → 按钮"添加音频文件"(调现有 dialog plugin) → 待处理文件列表(可键盘移除) → "开始分离"按钮 → `aria-live` 进度区 → 完成后"导出"按钮
+- **模型管理区**: 列表 + 安装/删除/导入按钮(复用 `useModelStore`)
+- **结果区**: 分离完成列表 + 原生 `<audio>` 预览 + 导出
+- **顶部条**: 返回主界面 / 切换语言 / 设置入口
+
+**复用**: 不重写分离逻辑,全部调现有 stores/actions;`worker.py` 与 Rust 层零改动。
+
+**缓解"分别但不平等"**:
+
+- 同一引擎、同一模型、同一分离质量、同一输出;文案叫"简化操作模式 / Simplified Mode",不叫"盲人版"
+- 简化页只覆盖分离 + 模型管理 + 结果;工作流编辑器和波形混音器不进简化页,盲人进阶用户走主界面(基线可达 + 文本大纲兜底)
+- 数据共享:简化页直接复用现有 stores,不另起状态,分叉风险主要在视图层
+
+## 3. 全局外壳与导航
+
+- **跳转链接**: `App.vue` 首个可聚焦元素加"跳到主内容";`<main id="main-content" tabindex="-1">`
+- **路由焦点 + 标题**: 路由切换时焦点移到 `<main>` 或视图标题;同步设置 `document.title`(TitleBar 显示了 `pageTitle` 但 `document.title` 未设,读屏靠标题播报导航)
+- **SideNav**: `<aside>` → `<nav aria-label="主导航">`;活动项加 `aria-current="page"`(现仅有 `.active` 样式类)
+- **启动遮罩**: `StartupOnboarding` 打开时焦点进首按钮并陷阱;`boot-splash` 给 `aria-hidden`(瞬态,不应被读)
+- `document.documentElement.lang` 已在 i18n 设好 ✓
+
+## 4. 标准视图(分离/模型/结果/设置)— 主界面路径
+
+查漏补缺(已有不错地基):
+
+- **SeparateView**: 已有 `role=listbox/option/aria-selected` ✓;4 个手写 `role="dialog"` 块过 `useFocusTrap`;分离任务进度接 `useLiveAnnouncer`(开始/完成/失败);文件拖放区改成可键盘操作(`tabindex` + Enter)
+- **ModelsView**: 已有 `aria-pressed/tabindex/aria-current` ✓;模型卡 Enter/Space 激活;下载进度接直播区
+- **SettingsView**: 已有 `aria-label` 侧栏 ✓;核对每个控件 label 关联;模型目录迁移进度直播
+- **ResultsView**: 结果列表补 `role`/表头/动作 `aria-label`
+
+## 5. 编辑器:混音器 + 传输条 + 波形 — 主界面路径
+
+- **传输条**: 已到位 ✓
+- **轨道行**: `@mousedown` 选择 → `useRovingTabindex`(↑↓ 切换、Enter 选中、M/S 静音独奏);选中状态经直播区播报
+- **跳转**: 已有 ArrowLeft/Right ±1s/±5s ✓;轨道聚焦时跳转,直播区口述时间码(节流,可开关)
+- **淡入淡出**: 若靠波形拖拽,确保 Inspector 里有数字输入框且带 label(可键盘编辑)
+- **波形 `EditorWaveform`**: `<canvas>` 加 `role="img"` + 描述性 `aria-label`(名称/声道/时长/淡入淡出);轨道头加 `SrText` 摘要(名称/声道/时长/淡入淡出/静音态);聚焦时口述响度概况(从 `peaks` 算一句,如"约 2.3s 处最响,后半段较安静")
+- **电平表**: `track-meter` 仅可视;聚焦时口述峰值数值(已有 `title` 但 title 不可靠)
+- **资源入轨**: `EditorAssetPanel` 每个资源加"加入时间线"动作(Enter/按钮 → `addTrackFromAsset`),替代鼠标拖拽
+
+## 6. 工作流节点编辑器 — 主界面路径(最深)
+
+1. **"图形大纲"替代视图**(主可访问路径): 工具栏加切换,画布换成 `role="tree"`/`role="treeitem"` 嵌套列表——步骤(含模型/输入/输出)→ 工具节点 → 保存目标 → 备注。按 WAI-ARIA 树模式箭头键导航
+2. **连接编辑**: 大纲树里每个步骤的输入用 `combobox` 选源(上一步输出/工具输出),替代拖线;复用现有 `buildWorkflowConsumedValueSetForDraft` 数据模型
+3. **画布可驱动**(C 的额外深度): `useRovingTabindex` 遍历节点,Enter 开节点编辑器,Delete 删除(已有快捷键 ✓),选择/缩放状态经直播区播报
+4. 复用已有 copy/paste/undo/redo 快捷键 ✓
+
+## 7. 对话框与遮罩审计
+
+盘点所有手写 `role="dialog"`(SeparateView×4、`CustomModelImportDialog`、`DownloadDetailModal`、`WorkflowRevisionConflictModal`):逐一核对**焦点陷阱 + 初始焦点 + Esc 关闭 + 焦点回归 + `aria-labelledby` 指向标题**。Naive UI 的 `n-dialog`/`n-modal` 自带陷阱,主要查手写那几个。
+
+## 8. 直播区与进度
+
+- 任务/下载/分离进度 → `useLiveAnnouncer`
+- **Toast**(`useMessage`): Naive UI 消息默认不被读屏播报 → 每个 `message.*` 调用旁挂一次播报
+- 播放/暂停/停止/跳转状态变化 → 播报
+
+## 9. 焦点样式与对比
+
+- 全局 `:focus-visible` 焦点环(自定义 `.chip`/`.nav-item`/`.track-row` 等都缺)
+- 定义可见焦点环 token,亮/暗主题都可见;复用现有主题 token 体系(`--primary` 等)
+
+## 10. i18n
+
+- 所有新 aria 串加进 `src/i18n/zh-CN.json` 和 `en.json`
+- `tests/i18nKeys.test.ts` 同步加键(它本来就校验两份一致)
+- 优先复用已有键(`common.collapse/minimize/maximize/close/undo/redo` 等)
+
+## 11. 测试与验证矩阵
+
+| 维度 | 做法 |
+|---|---|
+| NVDA | WebView2 下全视图键盘走查 |
+| Windows 讲述器 | 同上 |
+| JAWS(试用版) | 重点查自定义控件 quirks(树/列表框/combobox) |
+| 纯键盘 | 每个视图无鼠标完成主流程 |
+| 自动化 | dev-only 接入 axe-core,加 `tests/a11y` 冒烟(渲染视图跑规则) |
+| 快捷键帮助 | 复用 `useEditorShortcuts`,加一个"快捷键列表"对话框 |
+| CI | 现有 `pnpm test` 加 i18n 键校验已覆盖;axe 跑在 dev |
+
+## 12. 落地顺序(C 范围)
+
+1. 原语层(`A11yProvider`/`useLiveAnnouncer`/`useFocusTrap`/`useRovingTabindex`/`SrText`) + 全局外壳(跳转链接/路由焦点/标题/SideNav)
+2. **简化页 `/simple`**(尽早交付盲人核心路径价值)
+3. 对话框审计 + Toast/进度直播区
+4. 标准视图查漏(主界面:Separate/Models/Results/Settings)
+5. 编辑器(混音器轨道行键盘化 + 波形文本摘要 + 时间码播报)
+6. 工作流图形大纲 + 连接 combobox + 画布可驱动(最深,最后)
+7. 焦点样式 + axe 冒烟 + 三读屏走查
+
+## 13. 不在本期范围(YAGNI)
+
+- 声学声化(耳标/音高映射波形)——用户明确选不做
+- 读屏软件自动检测与自动跳转——涉隐私且不可靠
+- macOS VoiceOver 支持——当前只有 Windows 构建(AGENTS.md)
+- 高对比度主题单独实现——复用现有主题 token,仅保证焦点环可见即可
+- Rust/Python worker 层改动——WebView2 自动暴露 a11y 树,无需后端参与

--- a/docs/plans/2025-08-25-screen-reader-support-design.md
+++ b/docs/plans/2025-08-25-screen-reader-support-design.md
@@ -12,7 +12,7 @@
 
 Pymss Studio 是 Tauri 桌面应用(Vue 3 + Naive UI + Rust 编排 Python worker),核心功能是音源分离。代码库**已有部分可达性地基**:
 
-- Naive UI 组件自带 ARIA;手写 `role="dialog"`/`aria-modal` 出现在 SeparateView×4、`CustomModelImportDialog`、`DownloadDetailModal`、`WorkflowRevisionConflictModal`
+- Naive UI 组件自带 ARIA;手写 `role="dialog"`/`aria-modal` 共 **8 处**:SeparateView×4、ModelsView×1、`CustomModelImportDialog`、`DownloadDetailModal`、`WorkflowRevisionConflictModal`
 - `EditorTransportBar` 已有 `sr-only` 类、`aria-pressed`、`aria-label`
 - `SeparateView` 已有 `role="listbox"`/`role="option"`/`aria-selected`
 - `useEditorShortcuts.ts` 已有一套编辑器全局键盘快捷键(播放/停止/跳转 ±1s/±5s/静音/独奏/缩放/撤销重做/保存)
@@ -82,23 +82,24 @@ Tauri 用 WebView2(Chromium),MSAA/UIA 树自动暴露给读屏,**无需改 Rust 
 
 - **跳转链接**: `App.vue` 首个可聚焦元素加"跳到主内容";`<main id="main-content" tabindex="-1">`
 - **路由焦点 + 标题**: 路由切换时焦点移到 `<main>` 或视图标题;同步设置 `document.title`(TitleBar 显示了 `pageTitle` 但 `document.title` 未设,读屏靠标题播报导航)
-- **SideNav**: `<aside>` → `<nav aria-label="主导航">`;活动项加 `aria-current="page"`(现仅有 `.active` 样式类)
+- **SideNav**: `<aside>` → `<nav :aria-label="t('a11y.mainNav')">`;活动项加 `aria-current="page"`(现仅有 `.active` 样式类);导航名称和跳转链接文本均通过 i18n 键提供,不硬编码中文
 - **启动遮罩**: `StartupOnboarding` 打开时焦点进首按钮并陷阱;`boot-splash` 给 `aria-hidden`(瞬态,不应被读)
 - `document.documentElement.lang` 已在 i18n 设好 ✓
 
-## 4. 标准视图(分离/模型/结果/设置)— 主界面路径
+## 4. 标准视图(分离/模型/结果/设置/工作流列表)— 主界面路径
 
 查漏补缺(已有不错地基):
 
-- **SeparateView**: 已有 `role=listbox/option/aria-selected` ✓;4 个手写 `role="dialog"` 块过 `useFocusTrap`;分离任务进度接 `useLiveAnnouncer`(开始/完成/失败);文件拖放区改成可键盘操作(`tabindex` + Enter)
+- **SeparateView**: `role=listbox/option/aria-selected` 已有但需补完整 listbox 键盘行为(方向键/Home/End + 单一 tabstop,或改为普通列表按钮语义);4 个手写 `role="dialog"` 块过 `useFocusTrap`;分离任务进度接 `useLiveAnnouncer`(开始/完成/失败);文件拖放区改成可键盘操作(`tabindex` + Enter)
 - **ModelsView**: 已有 `aria-pressed/tabindex/aria-current` ✓;模型卡 Enter/Space 激活;下载进度接直播区
 - **SettingsView**: 已有 `aria-label` 侧栏 ✓;核对每个控件 label 关联;模型目录迁移进度直播
 - **ResultsView**: 结果列表补 `role`/表头/动作 `aria-label`
+- **WorkflowsView**: `SideNav.vue:21` 将 `/workflows` 作为一级导航项;对工作流列表页做全量审计:ARIA 结构、键盘可达性、焦点管理、新建/打开/删除操作结果经直播区播报
 
 ## 5. 编辑器:混音器 + 传输条 + 波形 — 主界面路径
 
 - **传输条**: 已到位 ✓
-- **轨道行**: `@mousedown` 选择 → `useRovingTabindex`(↑↓ 切换、Enter 选中、M/S 静音独奏);选中状态经直播区播报
+- **轨道行**: `@mousedown` 选择 → `useRovingTabindex`(↑↓ 切换、Enter 选中、**M 静音 / R 独奏**,与 `useEditorShortcuts.ts:75-81` 的实现一致);选中状态经直播区播报
 - **跳转**: 已有 ArrowLeft/Right ±1s/±5s ✓;轨道聚焦时跳转,直播区口述时间码(节流,可开关)
 - **淡入淡出**: 若靠波形拖拽,确保 Inspector 里有数字输入框且带 label(可键盘编辑)
 - **波形 `EditorWaveform`**: `<canvas>` 加 `role="img"` + 描述性 `aria-label`(名称/声道/时长/淡入淡出);轨道头加 `SrText` 摘要(名称/声道/时长/淡入淡出/静音态);聚焦时口述响度概况(从 `peaks` 算一句,如"约 2.3s 处最响,后半段较安静")
@@ -108,13 +109,13 @@ Tauri 用 WebView2(Chromium),MSAA/UIA 树自动暴露给读屏,**无需改 Rust 
 ## 6. 工作流节点编辑器 — 主界面路径(最深)
 
 1. **"图形大纲"替代视图**(主可访问路径): 工具栏加切换,画布换成 `role="tree"`/`role="treeitem"` 嵌套列表——步骤(含模型/输入/输出)→ 工具节点 → 保存目标 → 备注。按 WAI-ARIA 树模式箭头键导航
-2. **连接编辑**: 大纲树里每个步骤的输入用 `combobox` 选源(上一步输出/工具输出),替代拖线;复用现有 `buildWorkflowConsumedValueSetForDraft` 数据模型
+2. **连接编辑**: 大纲树里每个步骤的输入用 `combobox` 选源(上一步输出/工具输出),替代拖线;候选项逻辑当前位于 `WorkflowNodeEditor.vue` 的 `inputOptions(index)`(注:`buildWorkflowConsumedValueSetForDraft` 只统计已消费输出,不能生成候选源);**需提取并共享该候选项构建/校验逻辑**,供大纲树与画布共同消费,避免连接规则漂移
 3. **画布可驱动**(C 的额外深度): `useRovingTabindex` 遍历节点,Enter 开节点编辑器,Delete 删除(已有快捷键 ✓),选择/缩放状态经直播区播报
 4. 复用已有 copy/paste/undo/redo 快捷键 ✓
 
 ## 7. 对话框与遮罩审计
 
-盘点所有手写 `role="dialog"`(SeparateView×4、`CustomModelImportDialog`、`DownloadDetailModal`、`WorkflowRevisionConflictModal`):逐一核对**焦点陷阱 + 初始焦点 + Esc 关闭 + 焦点回归 + `aria-labelledby` 指向标题**。Naive UI 的 `n-dialog`/`n-modal` 自带陷阱,主要查手写那几个。
+盘点所有手写 `role="dialog"` 共 **8 处**(SeparateView×4、ModelsView×1、`CustomModelImportDialog`、`DownloadDetailModal`、`WorkflowRevisionConflictModal`):逐一核对**焦点陷阱 + 初始焦点 + Esc 关闭 + 焦点回归 + `aria-labelledby` 指向标题**。Naive UI 的 `n-dialog`/`n-modal` 自带陷阱,主要查手写那几个。
 
 ## 8. 直播区与进度
 

--- a/docs/plans/2025-08-25-screen-reader-support-implementation.md
+++ b/docs/plans/2025-08-25-screen-reader-support-implementation.md
@@ -38,7 +38,7 @@
 
 ### T1.3 `A11yProvider` 组件
 - **文件**: `src/components/A11yProvider.vue`(新增);`src/App.vue` 包一层
-- **做法**: 挂载 polite/assertive 两个 `aria-live` 区(absolute、clip、aria-hidden 视觉隐藏但读屏可读);提供跳转链接目标锚点;`<main id="main-content" tabindex="-1">` 由它管理 id
+- **做法**: 挂载 polite/assertive 两个 `aria-live` 区(absolute、clip 视觉隐藏,**不加 `aria-hidden`**——`aria-hidden` 会将节点从无障碍树中移除,导致读屏无法播报);提供跳转链接目标锚点;`<main id="main-content" tabindex="-1">` 由它管理 id
 - **验收**: DOM 里存在两个 live 区;读屏可读;`#main-content` 存在且可编程聚焦
 - **依赖**: T1.2
 
@@ -68,14 +68,14 @@
 
 ### T1.8 SideNav 语义化 + 跳转链接
 - **文件**: `src/components/SideNav.vue`(修改)、`src/App.vue`(修改)
-- **做法**: `<aside>` → `<nav aria-label="主导航">`;活动项加 `aria-current="page"`;App 顶部加"跳到主内容"跳转链接(首个可聚焦元素)
+- **做法**: `<aside>` → `<nav :aria-label="t('a11y.mainNav')">`;活动项加 `aria-current="page"`;App 顶部加跳转链接,文本用 `t('a11y.skipToContent')` i18n 键(所有新增导航标签与链接文本均通过 i18n 键提供,不硬编码中文,以保证英文界面读屏正确播报)
 - **验收**: 读屏识别为导航;活动项播报"当前页";跳转链接可 Tab 到并回车跳过导航
 - **依赖**: T1.3、T1.7
 
 ### T1.9 boot-splash 与 StartupOnboarding
 - **文件**: `src/App.vue`(修改)、`src/components/StartupOnboarding.vue`(修改)
-- **做法**: `boot-splash` 加 `aria-hidden="true"`(瞬态不读);`StartupOnboarding` 打开时焦点进首按钮 + 焦点陷阱
-- **验收**: 启动遮罩期读屏不读过渡;Onboarding 打开焦点进按钮、Tab 不逃逸
+- **做法**: `boot-splash` 加 `aria-hidden="true"`(瞬态不读);`StartupOnboarding` 打开时:①根节点改为 `role="dialog" aria-modal="true" :aria-labelledby` 指向内部标题;②焦点进首按钮 + 焦点陷阱;③Esc 关闭;④关闭后焦点回触发元素
+- **验收**: 启动遮罩期读屏不读过渡;Onboarding 打开焦点进按钮、Tab 不逃逸;读屏播报对话框标题;浏览模式不访问背景内容
 - **依赖**: T1.4
 
 **阶段 1 验收**: `pnpm build` 通过;纯键盘能跳过导航、切换视图、看到焦点环;读屏能播报路由标题;live 区已就位。
@@ -86,7 +86,7 @@
 
 ### T2.1 路由 + 视图骨架
 - **文件**: `src/router/index.ts`(加 `/simple` 路由)、`src/views/SimpleView.vue`(新增)
-- **做法**: hash 路由加 `{ path: '/simple', name: 'simple', component: ... }`;骨架为单列 `<main>` + `<h1>` + 若干 `<section aria-labelledby>`
+- **做法**: hash 路由加 `{ path: '/simple', name: 'simple', component: ... }`;骨架为单列普通容器 `<div>` + `<h1>` + 若干 `<section aria-labelledby>`(主 `<main>` landmark 由 App/A11yProvider 统一提供,视图内部不再渲染 `<main>`,避免嵌套 main landmark 导致读屏结构无效)
 - **验收**: 访问 `#/simple` 渲染骨架;读屏能读页面标题与各 section
 - **依赖**: 阶段 1
 
@@ -121,8 +121,8 @@
 - **依赖**: T2.1
 
 ### T2.7 i18n
-- **文件**: `src/i18n/zh-CN.json`、`src/i18n/en.json`(加 `simple.*` 键)、`tests/i18nKeys.test.ts`
-- **做法**: 所有简化页文案进 `simple` 命名空间;跑 i18n 键校验
+- **文件**: `src/i18n/zh-CN.json`、`src/i18n/en.json`(加 `simple.*` 键及 `nav.simple` 键)、`tests/i18nKeys.test.ts`
+- **做法**: 所有简化页文案进 `simple` 命名空间;**必须显式新增 `nav.simple` 键**(TitleBar 动态读取 `nav.${route.name}`，缺失时会显示/播报原始字符串 `nav.simple`)；同时在测试中加校验「每个命名路由都有对应 nav 标题键」；跑 i18n 键校验
 - **验收**: 两份 json 键一致;`pnpm test` i18n 用例通过
 - **依赖**: T2.3-T2.6
 
@@ -158,8 +158,8 @@
 ## 阶段 4 — 标准视图查漏(主界面)
 
 ### T4.1 SeparateView
-- **已有**: `role=listbox/option/aria-selected` ✓
-- **补**: 4 个 dialog 已在 T3.1 处理;文件拖放区改可键盘操作(`tabindex` + Enter 触发文件选择);分离任务进度已在 T3.3
+- **已有**: `role=listbox/option/aria-selected` 标注存在,但当前 `SeparateView.vue:1900-1982` 给每个普通按钮加了 `role="option"` 而**缺少 listbox 所需的单一 Tab 停靠点与方向键/Home/End 导航**,ARIA 角色与键盘行为不匹配
+- **补**: ①补齐 listbox 模式:使用 `useRovingTabindex` 实现方向键/Home/End 导航、单一 tabindex=0 停靠点;或②移除 listbox/option 角色改为普通列表按钮语义;选定方案后对齐实现与角色;4 个 dialog 已在 T3.1 处理;文件拖放区改可键盘操作(`tabindex` + Enter 触发文件选择);分离任务进度已在 T3.3
 - **验收**: 纯键盘能选模型/工作流、加文件、开始分离
 - **依赖**: 阶段 3
 
@@ -180,7 +180,12 @@
 - **验收**: 纯键盘改设置;每控件有可读 label
 - **依赖**: 阶段 2、3
 
-**阶段 4 验收**: 主界面四个标准视图纯键盘+读屏可用。
+### T4.5 WorkflowsView(工作流列表页)
+- **补**: `SideNav.vue:21` 将 `/workflows` 作为一级导航项;本任务对工作流列表/基础编辑页面做语义、键盘、焦点、状态播报全量审计:ARIA 结构、键盘可达性、焦点管理、关键操作结果经直播区播报
+- **验收**: 纯键盘能浏览工作流列表、新建/打开/删除工作流;操作结果被读屏播报
+- **依赖**: 阶段 3
+
+**阶段 4 验收**: 主界面五个标准视图(含 WorkflowsView)纯键盘+读屏可用。
 
 ---
 
@@ -236,7 +241,7 @@
 
 ### T6.2 连接 combobox 编辑
 - **文件**: 大纲树组件内
-- **做法**: 每个步骤的输入用 `combobox` 选源(上一步输出/工具输出),替代拖线;复用 `buildWorkflowConsumedValueSetForDraft`
+- **做法**: 每个步骤的输入用 `combobox` 选源(上一步输出/工具输出),替代拖线;候选项构建逻辑当前位于 `WorkflowNodeEditor.vue` 的 `inputOptions(index)`(注:`buildWorkflowConsumedValueSetForDraft` 只返回已消费输出集合,不能生成候选源);**需将 `inputOptions` 候选项构建/校验逻辑提取为共享函数**,供大纲树组件与 `WorkflowNodeEditor` 共同复用,避免两套连接规则漂移
 - **验收**: 纯键盘为步骤输入选源;保存后画布连接同步
 - **依赖**: T6.1
 
@@ -265,8 +270,8 @@
 
 ### T7.2 快捷键帮助对话框
 - **文件**: 新增 `src/components/ShortcutsHelpDialog.vue`;全局快捷键(如 `?`)打开
-- **做法**: 列出所有键盘快捷键(复用 `useEditorShortcuts` 定义);焦点陷阱
-- **验收**: `?` 打开;读屏读出快捷键列表;Esc 关
+- **做法**: 当前 `useEditorShortcuts.ts` 把按键写在 `switch` 中,无可供 UI 直接消费的元数据;**需先将快捷键定义提取为单一数据源**(如键 → 描述映射表),再由 `switch` 监听器和帮助对话框共同消费,避免两份快捷键清单漂移;对话框加焦点陷阱
+- **验收**: `?` 打开;读屏读出快捷键列表;Esc 关;快捷键定义仅维护一处
 - **依赖**: 阶段 1
 
 ### T7.3 三读屏走查

--- a/docs/plans/2025-08-25-screen-reader-support-implementation.md
+++ b/docs/plans/2025-08-25-screen-reader-support-implementation.md
@@ -1,0 +1,305 @@
+# Pymss Studio 读屏支持 — 实施计划
+
+- **对应设计**: `docs/plans/2025-08-25-screen-reader-support-design.md`(方案 C)
+- **分支**: `feat/screen-reader-support`(基于 `main@7c1a18e`)
+- **基线核对**: 2025-08-25 已对最新 main 重新核对
+  - `styles/global.scss` 存在但无 `:focus`/`:focus-visible` 样式 → 焦点环确为空白
+  - 手写 `role="dialog"` 共 8 处:SeparateView×4、ModelsView×1、`DownloadDetailModal`、`CustomModelImportDialog`、`WorkflowRevisionConflictModal`
+  - router 为 hash 路由,加 `/simple` 直接增条目即可
+  - `main.ts` bootstrap 清晰,stores 在 pinia 挂载后惰性初始化
+  - 已有 `useEditorShortcuts`、`EditorTransportBar` 的 `sr-only`/`aria-pressed`、`SeparateView` 的 `role=listbox/option` 等地基
+
+## 实施原则
+
+- **每个阶段可独立提交、可独立验证**;不依赖后续阶段即可运行
+- **每个任务给出验收标准**(读屏/键盘/自动三类)与**触及文件**
+- **i18n 双语同步**:`zh-CN.json` 与 `en.json` 必须同批改;改完跑 `tests/i18nKeys.test.ts`
+- **不碰 Rust / Python worker**:WebView2 自动暴露 a11y 树,后端零改动
+- **复用优先**:优先复用 Naive UI 自带 a11y 与已有 stores/actions,不重写业务逻辑
+- **提交粒度**:按阶段内的任务提交,commit message 用 `feat(a11y):` / `fix(a11y):` 前缀
+
+---
+
+## 阶段 1 — 原语层 + 全局外壳
+
+> 这一层是后续所有阶段的地基,且能立即提升全应用基线。最先做。
+
+### T1.1 `SrText` 全局 sr-only 文本组件
+- **文件**: `src/components/SrText.vue`(新增)
+- **做法**: 把 `EditorTransportBar.vue` 里内联的 `.sr-only` 提为可复用组件;`EditorTransportBar` 改为引用它
+- **验收**: 组件渲染为 `<span class="sr-only">`;视觉无变化;读屏能读出内容
+- **依赖**: 无
+
+### T1.2 `useLiveAnnouncer` 单例播报器
+- **文件**: `src/composables/useLiveAnnouncer.ts`(新增)
+- **做法**: 单例;`announce(text, { assertive })` 往两个 `aria-live` 区写入;节流策略(同文本 500ms 内去重;进度类每 1s 至多一次);暴露 `announcePolite`/`announceAssertive`
+- **验收**: 调用后读屏能听到;快速连续调用只播报节流后结果
+- **依赖**: T1.1(用 SrText 或直接 DOM 节点)
+
+### T1.3 `A11yProvider` 组件
+- **文件**: `src/components/A11yProvider.vue`(新增);`src/App.vue` 包一层
+- **做法**: 挂载 polite/assertive 两个 `aria-live` 区(absolute、clip、aria-hidden 视觉隐藏但读屏可读);提供跳转链接目标锚点;`<main id="main-content" tabindex="-1">` 由它管理 id
+- **验收**: DOM 里存在两个 live 区;读屏可读;`#main-content` 存在且可编程聚焦
+- **依赖**: T1.2
+
+### T1.4 `useFocusTrap` 焦点陷阱
+- **文件**: `src/composables/useFocusTrap.ts`(新增)
+- **做法**: `trap(el)` 记录当前焦点、监听 Tab/Shift+Tab 循环、Esc 关闭回调、`release()` 回归焦点;初次进入聚焦首个可聚焦元素或容器
+- **验收**: 在手写 dialog 内 Tab 不跳出;Esc 触发关闭回调;关闭后焦点回到触发按钮
+- **依赖**: 无
+
+### T1.5 `useRovingTabindex` 漫游焦点
+- **文件**: `src/composables/useRovingTabindex.ts`(新增)
+- **做法**: 通用容器内子项 roving tabindex(Home/End/Arrow 导航、方向可配水平/垂直/网格);暴露 `activate(index)` 与当前激活索引
+- **验收**: 容器内只有一个 tabindex=0,其余 -1;方向键移动焦点;Home/End 跳首尾
+- **依赖**: 无
+
+### T1.6 全局焦点环样式
+- **文件**: `src/styles/global.scss`(修改)
+- **做法**: 加全局 `:focus-visible` 焦点环(2px outline + offset),用主题 token;确保亮/暗主题都可见;为已知会吞掉焦点的自定义控件(`.chip`/`.nav-item`/`.track-row`)补 `:focus-visible`
+- **验收**: Tab 遍历任意控件都有可见焦点环;不依赖鼠标
+- **依赖**: 无
+
+### T1.7 路由焦点迁移 + document.title
+- **文件**: `src/router/index.ts`(修改)、`src/App.vue`(修改)
+- **做法**: 全局 `afterEach` 钩子把焦点移到 `#main-content` 或视图标题;同步 `document.title = pageTitle`(读屏靠标题播报导航)
+- **验收**: 路由切换后焦点到主区;读屏播报新页面标题
+- **依赖**: T1.3
+
+### T1.8 SideNav 语义化 + 跳转链接
+- **文件**: `src/components/SideNav.vue`(修改)、`src/App.vue`(修改)
+- **做法**: `<aside>` → `<nav aria-label="主导航">`;活动项加 `aria-current="page"`;App 顶部加"跳到主内容"跳转链接(首个可聚焦元素)
+- **验收**: 读屏识别为导航;活动项播报"当前页";跳转链接可 Tab 到并回车跳过导航
+- **依赖**: T1.3、T1.7
+
+### T1.9 boot-splash 与 StartupOnboarding
+- **文件**: `src/App.vue`(修改)、`src/components/StartupOnboarding.vue`(修改)
+- **做法**: `boot-splash` 加 `aria-hidden="true"`(瞬态不读);`StartupOnboarding` 打开时焦点进首按钮 + 焦点陷阱
+- **验收**: 启动遮罩期读屏不读过渡;Onboarding 打开焦点进按钮、Tab 不逃逸
+- **依赖**: T1.4
+
+**阶段 1 验收**: `pnpm build` 通过;纯键盘能跳过导航、切换视图、看到焦点环;读屏能播报路由标题;live 区已就位。
+
+---
+
+## 阶段 2 — 简化操作页 `/simple`(盲人核心路径,尽早交付价值)
+
+### T2.1 路由 + 视图骨架
+- **文件**: `src/router/index.ts`(加 `/simple` 路由)、`src/views/SimpleView.vue`(新增)
+- **做法**: hash 路由加 `{ path: '/simple', name: 'simple', component: ... }`;骨架为单列 `<main>` + `<h1>` + 若干 `<section aria-labelledby>`
+- **验收**: 访问 `#/simple` 渲染骨架;读屏能读页面标题与各 section
+- **依赖**: 阶段 1
+
+### T2.2 入口(三处)
+- **文件**: `src/components/SideNav.vue`(底部加入口)、`src/views/SettingsView.vue`(加入口)、`src/components/StartupOnboarding.vue`(提一句)
+- **做法**: SideNav 底部加"简化操作模式"链接(在 settings 上方);Onboarding 加一行说明;设置页加一个开关区
+- **验收**: 三处可达;点击跳 `/simple`
+- **依赖**: T2.1
+
+### T2.3 分离区(核心)
+- **文件**: `src/views/SimpleView.vue`(扩展)
+- **做法**: 复用 `useTaskStore`/`useModelStore`/`useWorkflowStore`;`<select>` 模型 / `<select>` 工作流 → 按钮"添加音频文件"(调 `@tauri-apps/plugin-dialog` open 多选)→ 待处理文件列表(每项有"移除"按钮)→ "开始分离"按钮 → 进度区接 `useLiveAnnouncer` → 完成后"导出"按钮
+- **验收**: 纯键盘能完成"选模型→加文件→开始→看进度→导出"全流程;进度被读屏播报
+- **依赖**: T2.1、T1.2
+
+### T2.4 模型管理区
+- **文件**: `src/views/SimpleView.vue`(扩展)
+- **做法**: 列表(模型名/状态)+ 安装/删除/导入按钮,调现有 `useModelStore` actions
+- **验收**: 纯键盘能安装/删除/导入模型;操作结果经 live 区播报
+- **依赖**: T2.1、T1.2
+
+### T2.5 结果区(原生 audio 播放)
+- **文件**: `src/views/SimpleView.vue`(扩展)
+- **做法**: 分离完成列表;每项用原生 `<audio controls>` 预览(读屏天然支持);导出按钮
+- **验收**: 读屏能操作原生 audio 控件;导出可用
+- **依赖**: T2.1
+
+### T2.6 顶部条
+- **文件**: `src/views/SimpleView.vue`
+- **做法**: "返回主界面"链接 / 语言切换 / 设置入口;`<h1>` 页面标题
+- **验收**: 三者可达;返回主界面跳 `/`
+- **依赖**: T2.1
+
+### T2.7 i18n
+- **文件**: `src/i18n/zh-CN.json`、`src/i18n/en.json`(加 `simple.*` 键)、`tests/i18nKeys.test.ts`
+- **做法**: 所有简化页文案进 `simple` 命名空间;跑 i18n 键校验
+- **验收**: 两份 json 键一致;`pnpm test` i18n 用例通过
+- **依赖**: T2.3-T2.6
+
+**阶段 2 验收**: 盲人用户走 `/simple` 纯键盘+读屏完成分离主流程;不碰画布/拖拽。
+
+---
+
+## 阶段 3 — 对话框审计 + Toast/进度直播
+
+### T3.1 手写 dialog 焦点陷阱审计(8 处)
+- **文件**: SeparateView(×4)、ModelsView(×1)、`DownloadDetailModal`、`CustomModelImportDialog`、`WorkflowRevisionConflictModal`
+- **做法**: 逐一核对 焦点陷阱(T1.4) + 初始焦点 + Esc 关闭 + 焦点回归 + `aria-labelledby` 指向标题;缺失项补齐
+- **验收**: 每个 dialog 打开焦点进、Tab 不逃逸、Esc 关、关后回触发按钮、标题被读
+- **依赖**: T1.4
+
+### T3.2 Toast 播报旁挂
+- **文件**: 新增 `src/composables/useAnnouncedMessage.ts`(包装 Naive UI `useMessage`)
+- **做法**: 提供 `useAnnouncedMessage()` 返回与 `useMessage` 同接口的包装;每次 `message.success/error/warning/info` 旁挂一次 `useLiveAnnouncer.announcePolite`
+- **验收**: 任意 `message.*` 调用后读屏播报;不破坏原 toast 行为
+- **依赖**: T1.2
+- **注**: 全量替换现有 `useMessage` 调用点工作量大,先建包装并在新代码用;迁移现有调用点作为渐进任务
+
+### T3.3 进度直播区接入
+- **文件**: `src/stores/task.ts`(任务进度)、`src/stores/model.ts`/相关下载(下载进度)、`src/stores/settings.ts`(迁移进度)
+- **做法**: 关键状态变化点(任务开始/完成/失败、下载百分比里程碑、迁移阶段)调 `useLiveAnnouncer`;节流避免噪音
+- **验收**: 分离任务全生命周期被读屏播报;下载进度按里程碑播报
+- **依赖**: T1.2
+
+**阶段 3 验收**: 所有手写 dialog 符合焦点规范;关键进度被读屏播报。
+
+---
+
+## 阶段 4 — 标准视图查漏(主界面)
+
+### T4.1 SeparateView
+- **已有**: `role=listbox/option/aria-selected` ✓
+- **补**: 4 个 dialog 已在 T3.1 处理;文件拖放区改可键盘操作(`tabindex` + Enter 触发文件选择);分离任务进度已在 T3.3
+- **验收**: 纯键盘能选模型/工作流、加文件、开始分离
+- **依赖**: 阶段 3
+
+### T4.2 ModelsView
+- **已有**: `aria-pressed/tabindex/aria-current` ✓
+- **补**: 模型卡 Enter/Space 激活(打开详情);下载进度已在 T3.3;dialog 已在 T3.1
+- **验收**: 纯键盘浏览/安装/删除/查看模型详情
+- **依赖**: 阶段 3
+
+### T4.3 ResultsView
+- **补**: 结果列表加 `role`/表头语义/动作按钮 `aria-label`
+- **验收**: 读屏能读出列表结构与每项可用操作
+- **依赖**: 无
+
+### T4.4 SettingsView
+- **已有**: `aria-label` 侧栏 ✓
+- **补**: 核对每个控件 label 关联;迁移进度已在 T3.3;简化模式入口已在 T2.2
+- **验收**: 纯键盘改设置;每控件有可读 label
+- **依赖**: 阶段 2、3
+
+**阶段 4 验收**: 主界面四个标准视图纯键盘+读屏可用。
+
+---
+
+## 阶段 5 — 编辑器(混音器 + 波形 + 传输条)
+
+### T5.1 轨道行键盘化(roving tabindex)
+- **文件**: `src/components/editor/EditorMixer.vue`(修改)
+- **做法**: `@mousedown` 选择 → `useRovingTabindex`(↑↓ 切换轨道、Enter 选中);M/S 静音独奏按钮已存在 ✓;选中状态经 `useLiveAnnouncer` 播报
+- **验收**: 纯键盘上下切轨道、选中、静音/独奏;读屏播报选中轨道
+- **依赖**: T1.2、T1.5
+
+### T5.2 跳转 + 时间码播报
+- **文件**: `src/composables/useEditorPlayback.ts` 或 `EditorView.vue`(接现有快捷键)
+- **做法**: 已有 ArrowLeft/Right ±1s/±5s ✓;轨道聚焦时跳转,直播区口述时间码(节流,播放中每 1s);传输条加"口述位置"开关
+- **验收**: 跳转/播放时读屏播报时间码;可关
+- **依赖**: T1.2、T5.1
+
+### T5.3 波形文本等价 + 轨道摘要
+- **文件**: `src/components/editor/EditorWaveform.vue`(修改)、`src/components/editor/EditorMixer.vue`(轨道头加摘要)
+- **做法**: `<canvas>` 加 `role="img"` + 描述性 `aria-label`(名称/声道/时长/淡入淡出);轨道头加 `SrText` 摘要(全状态);聚焦轨道时从 `peaks` 算一句响度概况播报
+- **验收**: 读屏能读出每轨完整摘要;聚焦时听到响度概况
+- **依赖**: T1.1、T1.2、T5.1
+
+### T5.4 电平表口述
+- **文件**: `src/components/editor/EditorMixer.vue`
+- **做法**: 轨道聚焦时口述峰值数值(已有 `title` 但不可靠)
+- **验收**: 聚焦轨道能听到当前电平
+- **依赖**: T5.1
+
+### T5.5 资源入轨键盘化
+- **文件**: `src/components/editor/EditorAssetPanel.vue`(修改)
+- **做法**: 每个资源加"加入时间线"动作(Enter/按钮 → `addTrackFromAsset`),替代鼠标拖拽
+- **验收**: 纯键盘能把资源加入时间线
+- **依赖**: 无
+
+### T5.6 淡入淡出可键盘编辑
+- **文件**: `src/components/editor/EditorInspectorPanel.vue`(核对)
+- **做法**: 确保淡入淡出有数字输入框且带 label(可键盘编辑),不依赖波形拖拽
+- **验收**: 纯键盘改淡入淡出数值
+- **依赖**: 无
+
+**阶段 5 验收**: 编辑器纯键盘完成"加轨/选轨/静音独奏/跳转/改淡入淡出/导出";波形信息以文本可达。
+
+---
+
+## 阶段 6 — 工作流节点编辑器(最深,最后)
+
+### T6.1 图形大纲替代视图(主可访问路径)
+- **文件**: `src/components/workflow/WorkflowNodeEditor.vue`(修改,加视图切换)、可能新增 `src/components/workflow/WorkflowOutlineTree.vue`
+- **做法**: 工具栏加切换;画布换成 `role="tree"`/`role="treeitem"` 嵌套列表(步骤[模型/输入/输出]→工具节点→保存目标→备注);WAI-ARIA 树模式箭头键导航
+- **验收**: 切到大纲视图后纯键盘树形浏览;读屏读出节点层级与内容
+- **依赖**: 阶段 1
+
+### T6.2 连接 combobox 编辑
+- **文件**: 大纲树组件内
+- **做法**: 每个步骤的输入用 `combobox` 选源(上一步输出/工具输出),替代拖线;复用 `buildWorkflowConsumedValueSetForDraft`
+- **验收**: 纯键盘为步骤输入选源;保存后画布连接同步
+- **依赖**: T6.1
+
+### T6.3 画布可驱动(额外深度)
+- **文件**: `src/components/workflow/WorkflowNodeEditor.vue`
+- **做法**: `useRovingTabindex` 遍历节点;Enter 开节点编辑器;Delete 删除(已有快捷键 ✓);选择/缩放状态经直播区播报
+- **验收**: 画布视图下纯键盘遍历节点、编辑、删除
+- **依赖**: T1.2、T1.5、T6.1
+
+### T6.4 复用已有快捷键
+- **做法**: copy/paste/undo/redo 已有 ✓;确认在大纲视图也生效
+- **验收**: 大纲视图下 Ctrl+C/V/Z/Y 工作
+- **依赖**: T6.1
+
+**阶段 6 验收**: 工作流编辑器有两条可达路径(大纲树 / 可驱动画布);纯键盘能创建/编辑/删除节点与连接。
+
+---
+
+## 阶段 7 — 验证与收尾
+
+### T7.1 axe-core 冒烟(dev-only)
+- **文件**: `package.json`(devDep 加 `axe-core`)、`tests/a11y/` 新增、`vite.config` dev 注入
+- **做法**: dev-only;渲染各视图跑 axe 规则;CI 不强制(避免环境依赖)
+- **验收**: dev 跑能产出违规清单
+- **依赖**: 各阶段完成
+
+### T7.2 快捷键帮助对话框
+- **文件**: 新增 `src/components/ShortcutsHelpDialog.vue`;全局快捷键(如 `?`)打开
+- **做法**: 列出所有键盘快捷键(复用 `useEditorShortcuts` 定义);焦点陷阱
+- **验收**: `?` 打开;读屏读出快捷键列表;Esc 关
+- **依赖**: 阶段 1
+
+### T7.3 三读屏走查
+- **做法**: NVDA + 讲述器 + JAWS(试用版)在 WebView2 下走查每视图主流程;记录问题并修
+- **验收**: 三读屏均能完成核心路径;JAWS 自定义控件(树/列表框/combobox)无重大 quirks
+- **依赖**: 全部功能阶段完成
+
+### T7.4 文档
+- **文件**: `README.md`/`README.zh-CN.md`(加"无障碍"小节)、`AGENTS.md`(加 a11y 维护说明)
+- **做法**: 说明简化页入口、快捷键、读屏测试矩阵
+- **验收**: 用户能从 README 找到无障碍功能
+- **依赖**: 无
+
+---
+
+## 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| 简化页与主界面特性分叉 | 明确简化页只覆盖分离+模型+结果;工作流/混音器不进简化页;共享 stores 不另起状态 |
+| Toast 旁挂迁移量大 | 先建包装(T3.2),新代码用;现有调用点渐进迁移,不阻塞 |
+| 工作流大纲与画布双向同步复杂 | 大纲为主可访问路径,画布可驱动为辅;大纲编辑直接写 graphDefinition,画布只是另一种渲染 |
+| JAWS 自定义控件 quirks | T7.3 重点测树/列表框/combobox;必要时回退到更朴素的原生控件 |
+| 焦点环与现有视觉冲突 | 用 `:focus-visible` 而非 `:focus`,仅键盘导航时显示,不影响鼠标点击观感 |
+
+## 建议提交节奏
+
+- 阶段 1: 一到两个 PR(原语层 / 全局外壳)
+- 阶段 2: 一个 PR(简化页完整)
+- 阶段 3: 一个 PR(对话框 + 直播)
+- 阶段 4: 一个 PR(标准视图查漏)
+- 阶段 5: 一个 PR(编辑器)
+- 阶段 6: 一到两个 PR(大纲 / 画布可驱动)
+- 阶段 7: 一个 PR(验证收尾)
+
+draft PR 先开,后续按阶段拆 PR 合并到本分支或直接进 main。

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,8 @@ import TitleBar from '@/components/TitleBar.vue'
 import SideNav from '@/components/SideNav.vue'
 import AppBrandMark from '@/components/AppBrandMark.vue'
 import StartupOnboarding from '@/components/StartupOnboarding.vue'
+import A11yProvider from '@/components/A11yProvider.vue'
+import ShortcutsHelpDialog from '@/components/ShortcutsHelpDialog.vue'
 import { useSettingsStore } from '@/stores/settings'
 import { useAppStore } from '@/stores/app'
 import { useUpdateStore } from '@/stores/update'
@@ -34,6 +36,7 @@ const manualUpdateModalVisible = ref(false)
 const manualUpdateError = ref('')
 const runtimeCorePromptVisible = ref(false)
 const runtimeCorePromptShown = ref(false)
+const shortcutsHelpVisible = ref(false)
 let unlistenNodeEditorClosed: UnlistenFn | undefined
 
 const isDark = computed(() => resolvedIsDark(settings.themeMode))
@@ -154,7 +157,28 @@ async function keepDeferredUpdateForNextLaunch() {
   }
 }
 
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const tag = target.tagName
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    target.isContentEditable
+  )
+}
+
+function onShortcutsHelpKeydown(event: KeyboardEvent) {
+  // "?" (Shift+/ on most layouts) opens the keyboard shortcuts help. Ignore
+  // key presses inside form fields so users can type "?" into inputs.
+  if (event.key === '?' && !event.ctrlKey && !event.metaKey && !isEditableTarget(event.target)) {
+    event.preventDefault()
+    shortcutsHelpVisible.value = true
+  }
+}
+
 onMounted(async () => {
+  window.addEventListener('keydown', onShortcutsHelpKeydown)
   window.setTimeout(() => {
     bootReady.value = true
   }, 120)
@@ -167,6 +191,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  window.removeEventListener('keydown', onShortcutsHelpKeydown)
   unlistenNodeEditorClosed?.()
 })
 
@@ -195,11 +220,12 @@ const themeOverrides = computed(() => getThemeOverrides(settings.themeMode, sett
       <n-message-provider>
         <n-dialog-provider>
         <div class="app-shell" :class="{ 'app-shell--editor': isStandaloneRoute, 'app-shell--workflow-node-editor': isWorkflowNodeEditorRoute, 'app-shell--native-titlebar': isMacOS, 'no-animations': !settings.animationsEnabled }">
+          <A11yProvider />
           <div class="app-backdrop" />
           <TitleBar v-if="!isWorkflowNodeEditorRoute" />
           <div class="app-body">
             <SideNav v-if="!isStandaloneRoute" />
-            <main class="app-content">
+            <main id="main-content" class="app-content" tabindex="-1">
               <router-view v-slot="{ Component, route }">
                 <component v-if="isWorkflowNodeEditorRoute" :is="Component" :key="route.fullPath" />
                 <transition v-else name="page" mode="out-in">
@@ -209,7 +235,7 @@ const themeOverrides = computed(() => getThemeOverrides(settings.themeMode, sett
             </main>
           </div>
           <transition name="boot-fade">
-            <div v-if="!bootReady" class="boot-splash">
+            <div v-if="!bootReady" class="boot-splash" aria-hidden="true">
               <AppBrandMark class="boot-splash__mark" :size="58" shadow />
             <div class="boot-splash__copy">
               <strong>Pymss Studio</strong>
@@ -218,6 +244,7 @@ const themeOverrides = computed(() => getThemeOverrides(settings.themeMode, sett
             </div>
           </transition>
           <StartupOnboarding v-if="showStartupOnboarding" />
+          <ShortcutsHelpDialog v-model:show="shortcutsHelpVisible" />
         </div>
         <n-modal v-model:show="deferredUpdateModalVisible" preset="dialog" type="warning" :mask-closable="false" :closable="false">
           <template #header>

--- a/src/components/A11yProvider.vue
+++ b/src/components/A11yProvider.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { LIVE_REGION_IDS } from '@/composables/useLiveAnnouncer'
+
+const { t } = useI18n()
+
+/**
+ * A11yProvider — mounts the global screen-reader infrastructure:
+ *   1. A skip-to-content link (the first focusable element on every page) so
+ *      keyboard users can bypass the sidebar.
+ *   2. Two visually-hidden `aria-live` regions (polite / assertive) that
+ *      `useLiveAnnouncer` writes announcements into.
+ *
+ * The `<main id="main-content" tabindex="-1">` target lives in App.vue; this
+ * component only needs to know its id so the skip link can point at it.
+ */
+const MAIN_CONTENT_ID = 'main-content'
+</script>
+
+<template>
+  <!-- Skip link: visually hidden until focused (see .skip-link in global.scss).
+       Must be the first focusable element so a single Tab reaches it. -->
+  <a
+    :href="`#${MAIN_CONTENT_ID}`"
+    class="skip-link"
+  >
+    {{ t('a11y.skipToContent') }}
+  </a>
+
+  <!-- Live regions: visually hidden but readable by screen readers.
+       aria-hidden is intentionally NOT set — that would silence them.
+       They are clipped off-screen instead. -->
+  <div
+    :id="LIVE_REGION_IDS.polite"
+    class="a11y-live-region"
+    aria-live="polite"
+    aria-atomic="true"
+  />
+  <div
+    :id="LIVE_REGION_IDS.assertive"
+    class="a11y-live-region"
+    aria-live="assertive"
+    aria-atomic="true"
+  />
+</template>
+
+<style scoped>
+.a11y-live-region {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  /* Keep it in the accessibility tree: do NOT set aria-hidden or display:none. */
+}
+</style>

--- a/src/components/CustomModelImportDialog.vue
+++ b/src/components/CustomModelImportDialog.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useMessage } from 'naive-ui'
 import { invoke } from '@tauri-apps/api/core'
 import { DocumentAttachOutline, FolderOpenOutline } from '@vicons/ionicons5'
 import { useModelStore, type CustomModelInspection } from '@/stores/model'
 import { formatBytes } from '@/utils/format'
+import { useFocusTrap } from '@/composables/useFocusTrap'
 
 const props = defineProps<{ show: boolean }>()
 const emit = defineEmits<{
@@ -39,6 +40,16 @@ const force = ref(false)
 
 const importState = computed(() => modelStore.customImportState)
 const importing = computed(() => importState.value.status === 'importing')
+
+// Focus trap for the dialog card.
+const dialogCardRef = ref<HTMLElement | null>(null)
+const focusTrap = useFocusTrap(dialogCardRef, {
+  onEsc: () => { if (!importing.value) emit('update:show', false) },
+})
+watch(() => props.show, (visible) => {
+  if (visible) nextTick(() => focusTrap.trap())
+  else focusTrap.release()
+}, { immediate: true })
 
 const modelTypeOptions = computed(() => {
   const known = inspection.value?.knownModelTypes || []
@@ -223,11 +234,13 @@ const nextDisabled = computed(() => {
     @update:show="(v: boolean) => emit('update:show', v)"
   >
     <n-card
+      ref="dialogCardRef"
       class="cmi-modal"
       :bordered="false"
       :closable="!importing"
       role="dialog"
       aria-modal="true"
+      :aria-label="t('models.customImportTitle')"
       @close="emit('update:show', false)"
     >
       <template #header>

--- a/src/components/DownloadDetailModal.vue
+++ b/src/components/DownloadDetailModal.vue
@@ -11,6 +11,7 @@ import {
 } from '@vicons/ionicons5'
 import type { DownloadLogEntry, DownloadTask } from '@/stores/model'
 import { formatBytes, formatSpeedMBps } from '@/utils/format'
+import { useFocusTrap } from '@/composables/useFocusTrap'
 
 const props = defineProps<{
   show: boolean
@@ -31,6 +32,16 @@ const message = useMessage()
 
 const logContainerRef = ref<HTMLElement | null>(null)
 const autoScroll = ref(true)
+
+// Focus trap for the dialog card.
+const dialogCardRef = ref<HTMLElement | null>(null)
+const focusTrap = useFocusTrap(dialogCardRef, {
+  onEsc: () => handleClose(),
+})
+watch(() => props.show, (visible) => {
+  if (visible) nextTick(() => focusTrap.trap())
+  else focusTrap.release()
+}, { immediate: true })
 
 const statusType = computed(() => {
   if (!props.task) return 'default'
@@ -161,11 +172,13 @@ function handleClose() {
     @update:show="(v: boolean) => emit('update:show', v)"
   >
     <n-card
+      ref="dialogCardRef"
       class="download-detail-modal"
       :bordered="false"
       closable
       role="dialog"
       aria-modal="true"
+      :aria-label="t('models.downloadDetailTitle')"
       @close="handleClose"
     >
       <template #header>

--- a/src/components/ShortcutsHelpDialog.vue
+++ b/src/components/ShortcutsHelpDialog.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+import { nextTick, ref, watch } from 'vue'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+
+/**
+ * ShortcutsHelpDialog — modal reference of every keyboard shortcut.
+ *
+ * Rendered through `<n-modal>` (portal + mask + transition) but focus
+ * containment, initial focus, and Esc-to-close are owned by `useFocusTrap`
+ * so the dialog behaves consistently with the rest of the a11y layer.
+ * n-modal's own auto-focus and close-on-esc are disabled to avoid fighting
+ * the trap.
+ *
+ * Opened globally from App.vue via the `?` key.
+ */
+const show = defineModel<boolean>('show', { default: false })
+
+const dialogRef = ref<HTMLElement | null>(null)
+const trap = useFocusTrap(dialogRef, {
+  onEsc: () => {
+    show.value = false
+  },
+})
+
+watch(show, async (visible) => {
+  if (visible) {
+    // n-modal teleports its content; wait for the DOM to settle before
+    // activating the trap so the container ref is populated.
+    await nextTick()
+    trap.trap()
+  } else {
+    trap.release()
+  }
+})
+
+interface ShortcutRow {
+  key: string
+  action: string
+}
+
+const editorShortcuts: ShortcutRow[] = [
+  { key: 'Space', action: 'Play / Pause' },
+  { key: 'Escape', action: 'Stop playback' },
+  { key: 'Delete / Backspace', action: 'Remove the selected track' },
+  { key: 'M', action: 'Toggle mute on the selected track' },
+  { key: 'R', action: 'Toggle solo on the selected track' },
+  { key: 'Home', action: 'Move the playhead to the start' },
+  { key: '+ / =', action: 'Zoom in' },
+  { key: '- / _', action: 'Zoom out' },
+  { key: 'ArrowLeft', action: 'Seek backward 1 second' },
+  { key: 'ArrowRight', action: 'Seek forward 1 second' },
+  { key: 'Shift + ArrowLeft', action: 'Seek backward 5 seconds' },
+  { key: 'Shift + ArrowRight', action: 'Seek forward 5 seconds' },
+  { key: 'Ctrl + S', action: 'Save the project' },
+  { key: 'Ctrl + Z', action: 'Undo' },
+  { key: 'Ctrl + Shift + Z / Ctrl + Y', action: 'Redo' },
+]
+
+const globalShortcuts: ShortcutRow[] = [
+  { key: 'Tab', action: 'Move focus to the next focusable element' },
+  { key: '?', action: 'Open this keyboard shortcuts help' },
+  { key: 'Escape', action: 'Close this dialog' },
+]
+
+/** Split a "A / B" key cell into individual <kbd> segments. */
+function splitKeys(value: string): string[] {
+  return value.split(' / ')
+}
+
+function close() {
+  show.value = false
+}
+</script>
+
+<template>
+  <n-modal
+    v-model:show="show"
+    :auto-focus="false"
+    :close-on-esc="false"
+    :mask-closable="true"
+    :bordered="false"
+    class="shortcuts-help-modal"
+  >
+    <div
+      ref="dialogRef"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      class="shortcuts-help"
+    >
+      <header class="shortcuts-help__header">
+        <h2 class="shortcuts-help__title">Keyboard shortcuts</h2>
+        <n-button
+          class="shortcuts-help__close"
+          quaternary
+          circle
+          aria-label="Close dialog"
+          @click="close"
+        >
+          ×
+        </n-button>
+      </header>
+
+      <div class="shortcuts-help__body">
+        <table class="shortcuts-table">
+          <thead>
+            <tr>
+              <th scope="col">Key</th>
+              <th scope="col">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="shortcuts-table__group">
+              <th colspan="2" scope="rowgroup">Editor</th>
+            </tr>
+            <tr v-for="(row, index) in editorShortcuts" :key="`editor-${index}`">
+              <td class="shortcuts-table__key">
+                <template v-for="(part, partIndex) in splitKeys(row.key)" :key="partIndex">
+                  <kbd>{{ part }}</kbd>
+                  <span v-if="partIndex < splitKeys(row.key).length - 1" class="shortcuts-table__sep"> / </span>
+                </template>
+              </td>
+              <td>{{ row.action }}</td>
+            </tr>
+          </tbody>
+          <tbody>
+            <tr class="shortcuts-table__group">
+              <th colspan="2" scope="rowgroup">Global</th>
+            </tr>
+            <tr v-for="(row, index) in globalShortcuts" :key="`global-${index}`">
+              <td class="shortcuts-table__key">
+                <template v-for="(part, partIndex) in splitKeys(row.key)" :key="partIndex">
+                  <kbd>{{ part }}</kbd>
+                  <span v-if="partIndex < splitKeys(row.key).length - 1" class="shortcuts-table__sep"> / </span>
+                </template>
+              </td>
+              <td>{{ row.action }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <footer class="shortcuts-help__footer">
+        <n-button type="primary" @click="close">Close</n-button>
+      </footer>
+    </div>
+  </n-modal>
+</template>
+
+<style scoped>
+.shortcuts-help-modal {
+  width: min(640px, calc(100vw - 32px));
+}
+
+.shortcuts-help {
+  width: min(640px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  overflow: auto;
+  background: var(--surface, #ffffff);
+  color: var(--on-surface, #1f2329);
+  border-radius: 12px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.28);
+  padding: 20px 24px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.shortcuts-help__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.shortcuts-help__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.shortcuts-help__body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.shortcuts-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.shortcuts-table th,
+.shortcuts-table td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--on-surface, #1f2329) 12%, transparent);
+  vertical-align: top;
+}
+
+.shortcuts-table thead th {
+  font-weight: 600;
+  color: var(--on-surface-muted, #6b7280);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.shortcuts-table__group th {
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--on-surface-muted, #6b7280);
+  background: color-mix(in srgb, var(--on-surface, #1f2329) 4%, transparent);
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.shortcuts-table__key {
+  white-space: nowrap;
+  width: 1%;
+}
+
+.shortcuts-table kbd {
+  display: inline-block;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1;
+  padding: 4px 6px;
+  border-radius: 5px;
+  border: 1px solid color-mix(in srgb, var(--on-surface, #1f2329) 20%, transparent);
+  background: color-mix(in srgb, var(--on-surface, #1f2329) 6%, transparent);
+  color: var(--on-surface, #1f2329);
+}
+
+.shortcuts-table__sep {
+  color: var(--on-surface-muted, #6b7280);
+}
+
+.shortcuts-help__footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 4px;
+}
+</style>

--- a/src/components/SideNav.vue
+++ b/src/components/SideNav.vue
@@ -10,6 +10,7 @@ import {
   FolderOpenOutline,
   SettingsOutline,
   TerminalOutline,
+  AccessibilityOutline,
 } from '@vicons/ionicons5'
 
 const route = useRoute()
@@ -22,13 +23,14 @@ const mainItems = computed(() => [
   { name: 'results', path: '/results', icon: FolderOpenOutline, label: t('nav.results') },
 ])
 const bottomItems = computed(() => [
+  { name: 'simple', path: '/simple', icon: AccessibilityOutline, label: t('nav.simple') },
   ...(settings.developerMode ? [{ name: 'debug', path: '/debug', icon: TerminalOutline, label: t('nav.debug') }] : []),
   { name: 'settings', path: '/settings', icon: SettingsOutline, label: t('nav.settings') },
 ])
 </script>
 
 <template>
-  <aside class="side-nav">
+  <nav class="side-nav" :aria-label="t('a11y.primaryNav')">
     <div class="side-nav__main">
       <router-link
         v-for="item in mainItems"
@@ -37,6 +39,7 @@ const bottomItems = computed(() => [
         :class="{ active: route.name === item.name }"
         :to="item.path"
         :title="item.label"
+        :aria-current="route.name === item.name ? 'page' : undefined"
       >
         <span class="nav-icon">
           <n-icon :component="item.icon" :size="18" />
@@ -56,6 +59,7 @@ const bottomItems = computed(() => [
         ]"
         :to="item.path"
         :title="item.label"
+        :aria-current="route.name === item.name ? 'page' : undefined"
       >
         <span class="nav-icon">
           <n-icon :component="item.icon" :size="18" />
@@ -63,5 +67,5 @@ const bottomItems = computed(() => [
         <span>{{ item.label }}</span>
       </router-link>
     </div>
-  </aside>
+  </nav>
 </template>

--- a/src/components/SrText.vue
+++ b/src/components/SrText.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+/**
+ * SrText — visually hidden text that remains available to screen readers.
+ *
+ * Renders a `<span class="sr-only">` by default. Use it to label icon-only
+ * buttons, add context to ambiguous controls, or provide off-screen
+ * announcements paired with `useLiveAnnouncer`.
+ *
+ * Pass `as="div"` (or any tag) when a block element is needed, e.g. inside
+ * a flex/grid context where an inline span would disturb layout.
+ */
+withDefaults(defineProps<{
+  as?: string
+}>(), {
+  as: 'span',
+})
+</script>
+
+<template>
+  <component :is="as" class="sr-only"><slot /></component>
+</template>
+
+<style scoped>
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>

--- a/src/components/StartupOnboarding.vue
+++ b/src/components/StartupOnboarding.vue
@@ -9,6 +9,7 @@ import AppBrandMark from '@/components/AppBrandMark.vue'
 import { SYSTEM_LOCALE, setLocale, type LocaleSetting } from '@/i18n'
 import { useSettingsStore } from '@/stores/settings'
 import { useAppStore, type RuntimeBackend } from '@/stores/app'
+import { useFocusTrap } from '@/composables/useFocusTrap'
 import { formatBytes } from '@/utils/format'
 import {
   detectRuntimePlatform,
@@ -303,6 +304,17 @@ async function finishOnboarding(event?: MouseEvent) {
   }
 }
 
+// Focus trap: confine Tab to the onboarding card so keyboard users don't
+// escape into the app behind it. Nested Naive UI modals (model-dir migration)
+// teleport to <body> and manage their own focus, so the trap is released while
+// any of them is open and re-armed when they close.
+const focusTrap = useFocusTrap(overlayRef)
+const hasOpenNestedModal = computed(() =>
+  checkingModelDir.value
+  || modelDirMigrationVisible.value
+  || modelDirMigrationState.value.status === 'confirm',
+)
+
 onMounted(() => {
   runtimeChecking.value = true
   app.checkRuntimeInfo()
@@ -311,17 +323,24 @@ onMounted(() => {
       runtimeChecking.value = false
     })
   void app.loadRuntimeCoreVersions().catch(() => {})
+  // Defer so the overlay DOM is settled before we capture focus.
+  requestAnimationFrame(() => focusTrap.trap())
+})
+
+watch(hasOpenNestedModal, (open) => {
+  if (open) focusTrap.release()
+  else requestAnimationFrame(() => focusTrap.trap())
 })
 </script>
 
 <template>
-  <div ref="overlayRef" class="onboarding-overlay">
+  <div ref="overlayRef" class="onboarding-overlay" role="dialog" aria-modal="true" aria-labelledby="onboarding-title">
     <div class="onboarding-card">
       <aside class="onboarding-rail">
         <div class="onboarding-brand">
           <AppBrandMark :size="46" variant="hero" shadow />
           <div class="onboarding-brand__text">
-            <strong>{{ t('onboarding.title') }}</strong>
+            <strong id="onboarding-title">{{ t('onboarding.title') }}</strong>
             <span>{{ t('onboarding.subtitle') }}</span>
           </div>
         </div>
@@ -348,6 +367,9 @@ onMounted(() => {
           </span>
           <h1>{{ stepMeta.title }}</h1>
           <p>{{ stepMeta.description }}</p>
+          <p v-if="step === 0" class="onboarding-hint onboarding-hint--a11y">
+            <router-link to="/simple" class="onboarding-simple-link">{{ t('simple.pageTitle') }} →</router-link>
+          </p>
         </header>
 
         <div class="onboarding-content__body">
@@ -818,6 +840,20 @@ onMounted(() => {
   color: var(--on-surface-muted);
   line-height: 1.6;
   font-size: 13px;
+}
+
+.onboarding-hint--a11y {
+  margin-top: 8px;
+}
+
+.onboarding-simple-link {
+  color: var(--primary-strong);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.onboarding-simple-link:hover {
+  text-decoration: underline;
 }
 
 .onboarding-content__body {

--- a/src/components/editor/EditorAssetPanel.vue
+++ b/src/components/editor/EditorAssetPanel.vue
@@ -159,6 +159,22 @@ function rowClass(source: EditorSource) {
   }
 }
 
+/**
+ * Accessible name for an asset row. Describes the "add to timeline" action and
+ * the asset's key metadata (duration, channels, sample rate) in plain English,
+ * since the row acts as a keyboard-activatable button.
+ */
+function assetRowAriaLabel(source: EditorSource) {
+  const duration = formatTime(source.duration)
+  const channels = source.channels
+    ? `${source.channels} channel${source.channels === 1 ? '' : 's'}`
+    : ''
+  const sampleRate = source.sampleRate ? `${Math.round(source.sampleRate / 100) / 10} kHz` : ''
+  const meta = [duration, channels, sampleRate].filter(Boolean).join(', ')
+  const status = source.missing ? ' (missing file)' : ''
+  return `Add ${source.name} to timeline. ${meta}${status}`
+}
+
 function hasSectionContent(type: 'local' | 'external') {
   if (search.value.trim()) {
     return type === 'local' ? filteredLocalSources.value.length > 0 : filteredExternalSources.value.length > 0
@@ -191,8 +207,13 @@ function hasSectionContent(type: 'local' | 'external') {
           class="asset-row"
           :class="rowClass(source)"
           :title="source.path"
+          tabindex="0"
+          role="button"
+          :aria-label="assetRowAriaLabel(source)"
           @mousedown="handleAssetPointerDown($event, source)"
           @dblclick="emit('sourceAdd', source)"
+          @keydown.enter.prevent="emit('sourceAdd', source)"
+          @keydown.space.prevent="emit('sourceAdd', source)"
           @contextmenu.stop.prevent="openContextMenu($event, source)"
         >
           <span class="asset-row__icon"><n-icon :component="source.missing ? AlertCircleOutline : MusicalNoteOutline" /></span>
@@ -211,8 +232,13 @@ function hasSectionContent(type: 'local' | 'external') {
           class="asset-row"
           :class="rowClass(source)"
           :title="source.path"
+          tabindex="0"
+          role="button"
+          :aria-label="assetRowAriaLabel(source)"
           @mousedown="handleAssetPointerDown($event, source)"
           @dblclick="emit('sourceAdd', source)"
+          @keydown.enter.prevent="emit('sourceAdd', source)"
+          @keydown.space.prevent="emit('sourceAdd', source)"
           @contextmenu.stop.prevent="openContextMenu($event, source)"
         >
           <span class="asset-row__icon"><n-icon :component="source.missing ? AlertCircleOutline : MusicalNoteOutline" /></span>

--- a/src/components/editor/EditorInspectorPanel.vue
+++ b/src/components/editor/EditorInspectorPanel.vue
@@ -161,6 +161,7 @@ const fadeMax = computed(() => props.selectedSource?.duration || 0)
                 :max="fadeMax"
                 :step="0.1"
                 size="small"
+                :input-props="{ 'aria-label': 'Fade in duration in seconds' }"
                 @update:value="(value: number | null) => selectedTrack && emit('setTrackFades', selectedTrack.id, { fadeIn: numberOrZero(value) })"
               />
             </label>
@@ -172,6 +173,7 @@ const fadeMax = computed(() => props.selectedSource?.duration || 0)
                 :max="fadeMax"
                 :step="0.1"
                 size="small"
+                :input-props="{ 'aria-label': 'Fade out duration in seconds' }"
                 @update:value="(value: number | null) => selectedTrack && emit('setTrackFades', selectedTrack.id, { fadeOut: numberOrZero(value) })"
               />
             </label>

--- a/src/components/editor/EditorMixer.vue
+++ b/src/components/editor/EditorMixer.vue
@@ -5,6 +5,9 @@ import { EllipsisHorizontal } from '@vicons/ionicons5'
 import type { DropdownOption } from 'naive-ui'
 import type { EditorSource, EditorTrack } from '@/types/editor'
 import EditorWaveform from '@/components/editor/EditorWaveform.vue'
+import SrText from '@/components/SrText.vue'
+import { useRovingTabindex } from '@/composables/useRovingTabindex'
+import { useLiveAnnouncer } from '@/composables/useLiveAnnouncer'
 import { formatTime, formatTimecode } from '@/utils/editorTime'
 
 const props = defineProps<{
@@ -77,6 +80,108 @@ const menuX = ref(0)
 const menuY = ref(0)
 const contextTrack = ref<EditorTrack | null>(null)
 const mixerRootEl = ref<HTMLElement | null>(null)
+
+const announcer = useLiveAnnouncer()
+const trackRowEls = ref<HTMLElement[]>([])
+
+// Roving tabindex for vertical (Up/Down) keyboard navigation between track
+// rows. Exactly one row carries tabindex="0"; the rest are -1 and reachable
+// only via arrow keys while the mixer has focus. Enter/Space selects the
+// focused row (handled in handleTrackKeydown below).
+const rove = useRovingTabindex(trackRowEls, {
+  orientation: 'vertical',
+  onActivate: (index) => {
+    // Announce the newly-focused track so arrow-key navigation is perceivable
+    // to screen reader users (the row has no formal role to convey its name).
+    const track = props.tracks[index]
+    if (track) {
+      announcer.announcePolite(`Track ${track.name}`)
+    }
+  },
+})
+
+function setTrackRowRef(el: unknown, index: number) {
+  // track-row is a plain <div>, so the ref is the HTMLElement itself.
+  if (!el) return
+  trackRowEls.value[index] = el as HTMLElement
+}
+
+// Keep the roving "active" slot aligned with the selected track so the next
+// Tab into the mixer lands on (or near) the selected row. We set activeIndex
+// directly — without calling focus() — so mouse selection never steals focus.
+watch(
+  () => props.selectedTrackId,
+  (id) => {
+    if (id == null) return
+    const idx = props.tracks.findIndex((track) => track.id === id)
+    if (idx >= 0 && idx !== rove.activeIndex.value) {
+      rove.activeIndex.value = idx
+    }
+  },
+  { immediate: true },
+)
+
+// Trim stale element refs when the track list shrinks so the roving tabindex
+// count stays in sync with the rendered rows.
+watch(
+  () => props.tracks.length,
+  (len) => {
+    if (trackRowEls.value.length > len) {
+      trackRowEls.value.length = len
+    }
+  },
+)
+
+function trackRowAriaLabel(track: EditorTrack) {
+  const source = sourceFor(track)
+  const channels = trackChannels(track)
+  const duration = source?.duration || 0
+  const states: string[] = []
+  if (track.muted) states.push('muted')
+  if (track.solo) states.push('solo')
+  let label = `Track ${track.name}`
+  if (channels > 0) label += `, ${channels} channel${channels === 1 ? '' : 's'}`
+  if (duration > 0) label += `, duration ${formatTime(duration)}`
+  if (states.length) label += `, ${states.join(' and ')}`
+  label += '. Press Enter or Space to select, Up and Down arrows to move between tracks.'
+  return label
+}
+
+/** Visually-hidden track state summary exposed to screen readers in the header. */
+function trackStateSummary(track: EditorTrack) {
+  const volume = Math.round(track.volume * 100)
+  const states: string[] = []
+  if (track.muted) states.push('muted')
+  if (track.solo) states.push('soloed')
+  const stateText = states.length ? `, ${states.join(' and ')}` : ''
+  return `Track ${track.name}${stateText}, volume ${volume} percent`
+}
+
+function announceTrackSelection(track: EditorTrack) {
+  const states: string[] = []
+  if (track.muted) states.push('muted')
+  if (track.solo) states.push('solo')
+  const stateText = states.length ? `, ${states.join(' and ')}` : ''
+  announcer.announcePolite(`Selected track ${track.name}${stateText}`)
+}
+
+function handleTrackKeydown(event: KeyboardEvent, track: EditorTrack, index: number) {
+  // Only act when the row itself (not an inner button/input) is focused, so the
+  // M/S and overflow-menu buttons keep their native Enter/Space behavior and
+  // don't get hijacked by the row handler.
+  const fromRowItself = event.target === event.currentTarget
+  if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+    if (!fromRowItself) return
+    event.preventDefault()
+    emit('selectTrack', track.id)
+    announceTrackSelection(track)
+    return
+  }
+  if (fromRowItself) {
+    // Delegate Arrow/Home/End to the roving tabindex handler.
+    rove.onKeydown(event, index)
+  }
+}
 
 const trackMenuOptions = computed<DropdownOption[]>(() => {
   const track = contextTrack.value
@@ -303,16 +408,21 @@ defineExpose({
 
       <div v-if="tracks.length" class="tracks">
         <div
-          v-for="track in tracks"
+          v-for="(track, index) in tracks"
           :key="track.id"
+          :ref="(el) => setTrackRowRef(el, index)"
           class="track-row"
           :data-track-id="track.id"
           :class="rowClass(track)"
+          :tabindex="rove.tabindexOf(index)"
+          :aria-label="trackRowAriaLabel(track)"
           @mousedown="emit('selectTrack', track.id)"
           @contextmenu.stop.prevent="openTrackContextMenu($event, track)"
           @mouseenter="allowAssetDrop(track.id)"
+          @keydown="handleTrackKeydown($event, track, index)"
         >
           <div class="track-row__head">
+            <SrText>{{ trackStateSummary(track) }}</SrText>
             <div class="track-row__body">
               <div class="track-row__title">
                 <span class="track-dot" :style="{ background: track.color || '#7aa2ff' }" />
@@ -364,6 +474,7 @@ defineExpose({
               <div class="track-wave__clip" :class="{ 'track-wave__clip--offline': sourceMissing(track) }" :style="{ width: `${trackClipWidth(track)}px` }">
                 <EditorWaveform
                   v-if="sourceFor(track) && !sourceMissing(track)"
+                  :track-name="track.name"
                   :peaks="sourceFor(track)?.peaks || []"
                   :channel-peaks="sourceFor(track)?.channelPeaks || []"
                   :channels="trackChannels(track)"

--- a/src/components/editor/EditorTransportBar.vue
+++ b/src/components/editor/EditorTransportBar.vue
@@ -14,6 +14,7 @@ import {
   VolumeMuteOutline,
 } from '@vicons/ionicons5'
 import { formatTime } from '@/utils/editorTime'
+import SrText from '@/components/SrText.vue'
 import type { TransportPendingAction, TransportVisualState } from '@/stores/editorPlayback'
 
 const props = defineProps<{
@@ -115,7 +116,7 @@ function clearTransportPressed() {
             :disabled="disabled || !canUndo"
             @click="emit('undo')"
           >
-            <span class="sr-only">{{ t('common.undo') }}</span>
+            <SrText>{{ t('common.undo') }}</SrText>
             <n-icon :component="ArrowUndoOutline" />
           </button>
           <button
@@ -126,7 +127,7 @@ function clearTransportPressed() {
             :disabled="disabled || !canRedo"
             @click="emit('redo')"
           >
-            <span class="sr-only">{{ t('common.redo') }}</span>
+            <SrText>{{ t('common.redo') }}</SrText>
             <n-icon :component="ArrowRedoOutline" />
           </button>
           <button
@@ -393,18 +394,6 @@ function clearTransportPressed() {
   color: var(--on-surface-muted);
   background: transparent;
   transition: color 140ms ease, background 140ms ease;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }
 
 .transport-chip:not(:disabled):hover {

--- a/src/components/editor/EditorWaveform.vue
+++ b/src/components/editor/EditorWaveform.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { formatTime } from '@/utils/editorTime'
 
 const TILE_CSS_WIDTH = 1024
 const MAX_TILE_BUFFER_WIDTH = 4096
@@ -16,6 +17,8 @@ const props = defineProps<{
   fadeOut?: number
   color?: string
   progress?: number
+  /** Track name used to build the screen-reader text equivalent for the canvas. */
+  trackName?: string
 }>()
 
 const rootEl = ref<HTMLElement | null>(null)
@@ -25,6 +28,28 @@ const tileIndexes = computed(() => Array.from({ length: tileCount.value }, (_, i
 const resolvedChannels = computed(() => {
   const peakChannels = props.channelPeaks?.filter(channel => channel.length).length || 0
   return Math.max(Number(props.channels || 0), peakChannels)
+})
+
+/**
+ * Descriptive text equivalent for the waveform graphic. The canvas itself is
+ * non-textual, so screen readers need a label covering the track name, channel
+ * count, duration, and any fade envelopes.
+ */
+const waveformAriaLabel = computed(() => {
+  const name = props.trackName || 'audio track'
+  const channels = resolvedChannels.value
+  const channelText = channels > 0
+    ? `${channels} channel${channels === 1 ? '' : 's'}`
+    : 'unknown channel count'
+  const durationText = props.duration > 0 ? formatTime(props.duration) : 'unknown duration'
+  let label = `Waveform for track ${name}, ${channelText}, duration ${durationText}`
+  if (props.fadeIn && props.fadeIn > 0) {
+    label += `, fade in ${props.fadeIn.toFixed(1)} seconds`
+  }
+  if (props.fadeOut && props.fadeOut > 0) {
+    label += `, fade out ${props.fadeOut.toFixed(1)} seconds`
+  }
+  return label
 })
 
 function resolveColor(): string {
@@ -174,12 +199,19 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div ref="rootEl" class="editor-waveform" :style="{ width: `${width}px`, height: `${height}px` }">
+  <div
+    ref="rootEl"
+    class="editor-waveform"
+    role="img"
+    :aria-label="waveformAriaLabel"
+    :style="{ width: `${width}px`, height: `${height}px` }"
+  >
     <canvas
       v-for="tileIndex in tileIndexes"
       :key="tileIndex"
       class="editor-waveform__tile"
       :data-tile-index="tileIndex"
+      aria-hidden="true"
     />
   </div>
 </template>

--- a/src/components/workflow/WorkflowNodeEditor.vue
+++ b/src/components/workflow/WorkflowNodeEditor.vue
@@ -49,6 +49,9 @@ import {
   utilitySelectionKey,
   zoomAroundPoint,
 } from '@/utils/workflowCanvas'
+import { useRovingTabindex } from '@/composables/useRovingTabindex'
+import { useLiveAnnouncer } from '@/composables/useLiveAnnouncer'
+import SrText from '@/components/SrText.vue'
 
 const definition = defineModel<Record<string, unknown>>('definition', { required: true })
 const props = defineProps<{
@@ -131,6 +134,7 @@ type SaveOutputItem = {
 
 const { t } = useI18n()
 const message = useMessage()
+const announcer = useLiveAnnouncer()
 
 const graphDefinition = ref<WorkflowGraphDefinition>(readWorkflowGraphDefinition(definition.value || {}))
 let lastSyncedDefinitionJson = JSON.stringify(serializeWorkflowGraphDefinition(graphDefinition.value))
@@ -437,6 +441,152 @@ const paletteItems = computed(() => {
   ]
   if (!keyword) return items
   return items.filter(item => `${item.title} ${item.desc}`.toLowerCase().includes(keyword))
+})
+
+// ── Outline tree view (Phase 6 a11y) ───────────────────────────────────────
+// A screen-reader-accessible flat list of the workflow graph nodes. Toggleable
+// from the canvas toolbar; when visible, the canvas is hidden (aria-hidden) so
+// SR users browse a simple tree instead of an SVG canvas.
+type OutlineViewMode = 'canvas' | 'outline'
+interface OutlineTreeNode {
+  key: string
+  kind: 'input' | 'step' | 'utility' | 'save'
+  name: string
+  typeLabel: string
+  hasChildren: boolean
+}
+const outlineViewMode = ref<OutlineViewMode>('canvas')
+const outlineContainerRef = ref<HTMLElement | null>(null)
+const outlineItemRefs = ref<HTMLElement[]>([])
+const collapsedOutlineKeys = ref<Set<string>>(new Set(['input', 'save']))
+const outlineTree = computed<OutlineTreeNode[]>(() => {
+  // Input always comes first; steps are never collapsed (no expandable
+  // children — stems aren't separate nodes here); utilities last; save at end.
+  const nodes: OutlineTreeNode[] = [{
+    key: 'input',
+    kind: 'input',
+    name: t('workflows.originalInput'),
+    typeLabel: 'Input',
+    hasChildren: steps.value.length > 0,
+  }]
+  steps.value.forEach((step, index) => {
+    nodes.push({
+      key: stepSelectionKey(step.id),
+      kind: 'step',
+      name: stepDisplayId(index),
+      typeLabel: 'Separation step',
+      hasChildren: step.stems.length > 0,
+    })
+  })
+  utilityNodes.value.forEach((node) => {
+    nodes.push({
+      key: utilitySelectionKey(node.id),
+      kind: 'utility',
+      name: utilityNodeDisplayLabel(node),
+      typeLabel: utilityNodeTitle(node.kind),
+      hasChildren: false,
+    })
+  })
+  nodes.push({
+    key: 'save',
+    kind: 'save',
+    name: t('workflows.saveNode'),
+    typeLabel: 'Save',
+    hasChildren: saveOutputs.value.length > 0,
+  })
+  return nodes
+})
+// Flat list of visible tree items (collapsed parents hide their children).
+const outlineVisibleNodes = computed<OutlineTreeNode[]>(() => {
+  const collapsed = collapsedOutlineKeys.value
+  return outlineTree.value.filter((node) => {
+    if (!node.hasChildren) return true
+    // A parent with children is always visible; collapsing only affects its
+    // children — but since this is a flat list (no nested treeitems), we keep
+    // all rows visible and use aria-expanded purely as a state indicator.
+    return true
+  })
+})
+const outlineRove = useRovingTabindex(outlineItemRefs, {
+  orientation: 'vertical',
+  onActivate: (index) => {
+    const node = outlineVisibleNodes.value[index]
+    if (node) selectGraphNode(node.key)
+  },
+})
+const outlineNodeByIndex = (index: number) => outlineVisibleNodes.value[index]
+function outlineIsCollapsed(key: string) {
+  return collapsedOutlineKeys.value.has(key)
+}
+function toggleOutlineNode(key: string) {
+  const next = new Set(collapsedOutlineKeys.value)
+  if (next.has(key)) next.delete(key)
+  else next.add(key)
+  collapsedOutlineKeys.value = next
+}
+function openOutlineNodeEditor(node: OutlineTreeNode) {
+  if (node.kind === 'input') {
+    selectGraphNode('input')
+    return
+  }
+  if (node.kind === 'step') {
+    selectGraphNode(node.key)
+    return
+  }
+  if (node.kind === 'utility') {
+    openUtilityConfig(node.key.slice('utility:'.length))
+    return
+  }
+  if (node.kind === 'save') {
+    openSaveConfig()
+  }
+}
+function handleOutlineKeydown(event: KeyboardEvent, index: number) {
+  const node = outlineNodeByIndex(index)
+  if (!node) {
+    outlineRove.onKeydown(event, index)
+    return
+  }
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    event.stopPropagation()
+    openOutlineNodeEditor(node)
+    announcer.announcePolite(`Opening ${node.name}`)
+    return
+  }
+  if (event.key === 'ArrowRight' && node.hasChildren && outlineIsCollapsed(node.key)) {
+    event.preventDefault()
+    event.stopPropagation()
+    toggleOutlineNode(node.key)
+    announcer.announcePolite(`${node.name} expanded`)
+    return
+  }
+  if (event.key === 'ArrowLeft' && node.hasChildren && !outlineIsCollapsed(node.key)) {
+    event.preventDefault()
+    event.stopPropagation()
+    toggleOutlineNode(node.key)
+    announcer.announcePolite(`${node.name} collapsed`)
+    return
+  }
+  outlineRove.onKeydown(event, index)
+}
+function setOutlineViewMode(mode: OutlineViewMode) {
+  outlineViewMode.value = mode
+  if (mode === 'outline') {
+    announcer.announcePolite(`Outline view. ${outlineVisibleNodes.value.length} items. Use Up and Down arrows to navigate.`)
+    void nextTick(() => {
+      const el = outlineItemRefs.value[outlineRove.activeIndex.value]
+      if (el) el.focus()
+    })
+  } else {
+    announcer.announcePolite('Canvas view')
+  }
+}
+// Keep the item-ref array sized to the visible node list (refs bind by index).
+watch(() => outlineVisibleNodes.value.length, () => {
+  if (outlineRove.activeIndex.value >= outlineVisibleNodes.value.length && outlineVisibleNodes.value.length > 0) {
+    outlineRove.activeIndex.value = outlineVisibleNodes.value.length - 1
+  }
 })
 
 function graphNodeById(id: string) {
@@ -3608,10 +3758,12 @@ function jumpMinimap(event: MouseEvent) {
   <div class="node-editor-frame">
     <div class="node-editor-shell">
       <section
+        v-show="outlineViewMode === 'canvas'"
         ref="canvasViewportRef"
         class="node-canvas-wrap"
         :class="{ 'node-canvas-wrap--space-panning': spacePanning }"
         :style="viewportStyle"
+        :aria-hidden="outlineViewMode === 'outline'"
         @wheel="handleCanvasWheel"
         @contextmenu="handleCanvasContextMenu"
         @pointerdown="beginCanvasPan"
@@ -3641,6 +3793,16 @@ function jumpMinimap(event: MouseEvent) {
           <n-button size="small" quaternary @click="autoLayoutGraph">
             {{ t('workflows.autoLayout') }}
           </n-button>
+          <button
+            type="button"
+            class="outline-toggle-btn"
+            :aria-pressed="outlineViewMode === 'outline'"
+            :title="outlineViewMode === 'outline' ? 'Switch to Canvas view' : 'Switch to Outline view (accessible tree)'"
+            @click="setOutlineViewMode(outlineViewMode === 'outline' ? 'canvas' : 'outline')"
+          >
+            <SrText>{{ outlineViewMode === 'outline' ? 'Canvas view' : 'Outline view' }}</SrText>
+            <span aria-hidden="true">{{ outlineViewMode === 'outline' ? '▦' : '☰' }}</span>
+          </button>
         </div>
 
         <div v-if="pendingConnection" class="connection-banner canvas-floating" :class="{ 'connection-banner--locked': pendingConnectionTargetLabel }">
@@ -4266,6 +4428,52 @@ function jumpMinimap(event: MouseEvent) {
           </svg>
         </div>
       </section>
+
+      <section
+        v-show="outlineViewMode === 'outline'"
+        ref="outlineContainerRef"
+        class="outline-tree-wrap"
+        :aria-hidden="outlineViewMode === 'canvas'"
+        aria-label="Workflow outline"
+      >
+        <div class="outline-tree-header">
+          <strong>Workflow outline</strong>
+          <span class="outline-tree-header__count">{{ outlineVisibleNodes.length }} items</span>
+        </div>
+        <ul role="tree" aria-label="Workflow nodes" class="outline-tree">
+          <li
+            v-for="(node, index) in outlineVisibleNodes"
+            :key="node.key"
+            :ref="(el) => { if (el) outlineItemRefs[index] = el as HTMLElement }"
+            role="treeitem"
+            :aria-label="`${node.typeLabel}: ${node.name}`"
+            :aria-expanded="node.hasChildren ? !outlineIsCollapsed(node.key) : undefined"
+            :aria-selected="isGraphNodeSelected(node.key)"
+            :tabindex="outlineRove.tabindexOf(index)"
+            class="outline-tree__item"
+            :class="{
+              'outline-tree__item--selected': isGraphNodeSelected(node.key),
+              [`outline-tree__item--${node.kind}`]: true,
+            }"
+            @keydown="handleOutlineKeydown($event, index)"
+            @click="outlineRove.activate(index)"
+          >
+            <span class="outline-tree__indent" aria-hidden="true" />
+            <span
+              v-if="node.hasChildren"
+              class="outline-tree__chevron"
+              :class="{ 'outline-tree__chevron--collapsed': outlineIsCollapsed(node.key) }"
+              aria-hidden="true"
+            >▾</span>
+            <span v-else class="outline-tree__chevron outline-tree__chevron--blank" aria-hidden="true" />
+            <span class="outline-tree__type">{{ node.typeLabel }}</span>
+            <span class="outline-tree__name">{{ node.name }}</span>
+          </li>
+        </ul>
+        <p class="outline-tree__hint">
+          Use Up and Down arrows to move between items. Enter opens the node. Left and Right collapse or expand a group.
+        </p>
+      </section>
     </div>
 
     <footer class="node-editor-footer">
@@ -4648,6 +4856,165 @@ function jumpMinimap(event: MouseEvent) {
 .node-canvas-wrap:active,
 .node-canvas-wrap--space-panning {
   cursor: grabbing;
+}
+
+/* ── Outline tree view (Phase 6 a11y) ─────────────────────────────────── */
+.outline-tree-wrap {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  padding: 18px 18px 28px;
+  background-color: color-mix(in srgb, var(--surface-1) 92%, transparent);
+}
+
+.outline-tree-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--outline) 44%, transparent);
+}
+
+.outline-tree-header strong {
+  font-size: 14px;
+  color: var(--on-surface);
+}
+
+.outline-tree-header__count {
+  font-size: 12px;
+  color: var(--on-surface-muted);
+}
+
+.outline-tree {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.outline-tree__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--on-surface);
+  font-size: 13px;
+  line-height: 1.4;
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+}
+
+.outline-tree__item:focus-visible {
+  border-color: color-mix(in srgb, var(--primary) 64%, var(--outline));
+  background: color-mix(in srgb, var(--primary-soft) 18%, var(--surface-1));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 38%, transparent);
+}
+
+.outline-tree__item--selected {
+  background: color-mix(in srgb, var(--primary-soft) 26%, var(--surface-1));
+  border-color: color-mix(in srgb, var(--primary) 42%, var(--outline));
+}
+
+.outline-tree__item--selected:focus-visible {
+  background: color-mix(in srgb, var(--primary-soft) 32%, var(--surface-1));
+}
+
+.outline-tree__chevron {
+  flex: 0 0 auto;
+  width: 16px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--on-surface-muted);
+  transition: transform 0.12s ease;
+}
+
+.outline-tree__chevron--collapsed {
+  transform: rotate(-90deg);
+}
+
+.outline-tree__chevron--blank {
+  visibility: hidden;
+}
+
+.outline-tree__type {
+  flex: 0 0 auto;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--on-surface-muted);
+  background: color-mix(in srgb, var(--outline) 22%, transparent);
+}
+
+.outline-tree__item--input .outline-tree__type {
+  color: color-mix(in srgb, var(--primary-strong) 80%, white);
+  background: color-mix(in srgb, var(--primary-soft) 40%, transparent);
+}
+
+.outline-tree__item--save .outline-tree__type {
+  color: color-mix(in srgb, #22c55e 72%, white 8%);
+  background: color-mix(in srgb, #22c55e 18%, transparent);
+}
+
+.outline-tree__name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.outline-tree__hint {
+  margin: 14px 0 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--on-surface-muted);
+}
+
+.outline-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--outline) 56%, transparent);
+  background: color-mix(in srgb, var(--surface-1) 90%, transparent);
+  color: var(--on-surface);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  outline: none;
+}
+
+.outline-toggle-btn:hover {
+  border-color: color-mix(in srgb, var(--primary) 48%, var(--outline));
+  background: color-mix(in srgb, var(--primary-soft) 18%, var(--surface-1));
+}
+
+.outline-toggle-btn:focus-visible {
+  border-color: color-mix(in srgb, var(--primary) 72%, var(--outline));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 38%, transparent);
+}
+
+.outline-toggle-btn[aria-pressed="true"] {
+  border-color: color-mix(in srgb, var(--primary) 64%, var(--outline));
+  background: color-mix(in srgb, var(--primary-soft) 30%, var(--surface-1));
+  color: var(--primary-strong);
+}
+
+.outline-toggle-btn span[aria-hidden="true"] {
+  font-size: 14px;
+  line-height: 1;
 }
 
 .node-canvas-grid {

--- a/src/components/workflow/WorkflowRevisionConflictModal.vue
+++ b/src/components/workflow/WorkflowRevisionConflictModal.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useFocusTrap } from '@/composables/useFocusTrap'
 
-defineProps<{
+const props = defineProps<{
   show: boolean
   workflowName: string
 }>()
@@ -15,6 +17,16 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
+// Focus trap for the conflict dialog.
+const dialogCardRef = ref<HTMLElement | null>(null)
+const focusTrap = useFocusTrap(dialogCardRef, {
+  onEsc: () => emit('update:show', false),
+})
+watch(() => props.show, (visible) => {
+  if (visible) nextTick(() => focusTrap.trap())
+  else focusTrap.release()
+}, { immediate: true })
+
 function resolve(action: 'reload' | 'save-copy' | 'overwrite') {
   emit('update:show', false)
   if (action === 'reload') emit('reload')
@@ -26,11 +38,13 @@ function resolve(action: 'reload' | 'save-copy' | 'overwrite') {
 <template>
   <n-modal :show="show" :mask-closable="false" @update:show="emit('update:show', $event)">
     <n-card
+      ref="dialogCardRef"
       class="workflow-conflict-modal"
       :title="t('workflows.revisionConflictTitle')"
       :bordered="false"
       role="dialog"
       aria-modal="true"
+      :aria-label="t('workflows.revisionConflictTitle')"
     >
       <p>{{ t('workflows.revisionConflictHint', { name: workflowName }) }}</p>
       <template #footer>

--- a/src/composables/useAnnouncedMessage.ts
+++ b/src/composables/useAnnouncedMessage.ts
@@ -1,0 +1,53 @@
+import { useMessage } from 'naive-ui'
+import { useLiveAnnouncer } from '@/composables/useLiveAnnouncer'
+
+/**
+ * useAnnouncedMessage — a drop-in replacement for Naive UI's `useMessage`
+ * that also announces every toast to screen readers via the live region.
+ *
+ * Usage:
+ *   const message = useAnnouncedMessage()
+ *   message.success('Saved')  // shows a toast AND announces to SR
+ *
+ * New code should use this instead of `useMessage`. Existing call sites can
+ * be migrated incrementally — the interface is identical.
+ */
+export function useAnnouncedMessage() {
+  const raw = useMessage()
+  const announcer = useLiveAnnouncer()
+
+  function announce(text: string, assertive = false) {
+    const content = String(text || '').replace(/<[^>]*>/g, '').trim()
+    if (!content) return
+    if (assertive) announcer.announceAssertive(content)
+    else announcer.announcePolite(content)
+  }
+
+  // Wrap the primary methods so each call also announces to screen readers.
+  function wrapMethod(methodName: 'success' | 'error' | 'warning' | 'info' | 'loading', assertive = false) {
+    return function (...args: any[]) {
+      const fn = (raw as any)[methodName] as Function
+      const result = fn.apply(raw, args as any)
+      if (typeof args[0] === 'string') announce(args[0], assertive)
+      return result
+    }
+  }
+
+  const wrapped = {
+    success: wrapMethod('success'),
+    error: wrapMethod('error', true),
+    warning: wrapMethod('warning', true),
+    info: wrapMethod('info'),
+    loading: wrapMethod('loading'),
+  }
+
+  // Return a proxy that uses wrapped methods for the primary API and falls
+  // back to the raw message instance for everything else (destroyAll, etc.).
+  return new Proxy(wrapped, {
+    get(target, prop, receiver) {
+      if (prop in target) return (target as any)[prop]
+      const value = (raw as any)[prop]
+      return typeof value === 'function' ? value.bind(raw) : value
+    },
+  }) as typeof raw
+}

--- a/src/composables/useFocusTrap.ts
+++ b/src/composables/useFocusTrap.ts
@@ -1,0 +1,156 @@
+import { onBeforeUnmount, ref, type Ref } from 'vue'
+
+/**
+ * useFocusTrap — keyboard focus containment for hand-written overlays.
+ *
+ * Naive UI's `n-modal` already traps focus correctly; this composable is for
+ * the custom `role="dialog"` blocks scattered across the app that render
+ * outside of `n-modal`. It records the element that had focus when `trap()`
+ * was called, confines Tab/Shift+Tab to the container's focusable descendants,
+ * fires an Esc callback, and restores focus to the trigger on `release()`.
+ *
+ * Usage:
+ *   const overlayRef = ref<HTMLElement | null>(null)
+ *   const trap = useFocusTrap(overlayRef, { onEsc: () => (open.value = false) })
+ *   watch(open, (v) => v ? trap.trap() : trap.release())
+ */
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable="true"]',
+].join(',')
+
+export interface FocusTrapOptions {
+  /** Called when the user presses Escape inside the trap. */
+  onEsc?: () => void
+  /**
+   * Selector for the element to focus when the trap activates. Defaults to the
+   * first focusable descendant of the container (or the container itself when
+   * it has tabindex >= 0).
+   */
+  initialFocusSelector?: string
+  /** When true, focus is restored to the pre-trap element on release. Default true. */
+  restoreFocus?: boolean
+}
+
+export interface FocusTrapHandle {
+  /** Activate the trap on the bound container. Safe to call repeatedly. */
+  trap: () => void
+  /** Deactivate the trap and (by default) return focus to the trigger. */
+  release: () => void
+  /** Whether the trap is currently active. */
+  active: Ref<boolean>
+}
+
+function getFocusable(root: HTMLElement): HTMLElement[] {
+  const nodes = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+  // Filter out elements that are not actually reachable: hidden, or inside a
+  // closed details/inert subtree. A lightweight visibility check is enough for
+  // the hand-written dialogs in this app.
+  return nodes.filter((el) => {
+    if (el.hasAttribute('inert')) return false
+    if (el.closest('[inert]')) return false
+    return el.offsetParent !== null || el === document.activeElement
+      || getComputedStyle(el).position === 'fixed'
+  })
+}
+
+export function useFocusTrap(
+  target: Ref<HTMLElement | null>,
+  options: FocusTrapOptions = {},
+): FocusTrapHandle {
+  const { onEsc, initialFocusSelector, restoreFocus = true } = options
+  const active = ref(false)
+  let previouslyFocused: HTMLElement | null = null
+  let container: HTMLElement | null = null
+
+  function onKeydown(event: KeyboardEvent) {
+    if (!active.value || !container) return
+    if (event.key === 'Escape') {
+      event.stopPropagation()
+      onEsc?.()
+      return
+    }
+    if (event.key !== 'Tab') return
+    const focusable = getFocusable(container)
+    if (focusable.length === 0) {
+      // Nothing to cycle to — keep focus on the container itself.
+      event.preventDefault()
+      container.focus()
+      return
+    }
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    const current = document.activeElement as HTMLElement | null
+    if (event.shiftKey) {
+      if (current === first || !container.contains(current)) {
+        event.preventDefault()
+        last.focus()
+      }
+    } else {
+      if (current === last || !container.contains(current)) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+  }
+
+  function trap() {
+    const el = target.value
+    if (!el || active.value) return
+    container = el
+    active.value = true
+    previouslyFocused = document.activeElement as HTMLElement | null
+
+    // Make the container programmatically focusable so it can receive focus
+    // even when it has no focusable children.
+    if (!el.hasAttribute('tabindex')) {
+      el.setAttribute('tabindex', '-1')
+    }
+
+    document.addEventListener('keydown', onKeydown, true)
+
+    // Defer the initial focus to the next frame so any teleported content
+    // (Naive UI portals) has a chance to mount.
+    requestAnimationFrame(() => {
+      if (!container) return
+      let target2: HTMLElement | null = null
+      if (initialFocusSelector) {
+        target2 = container.querySelector<HTMLElement>(initialFocusSelector)
+      }
+      if (!target2) {
+        const focusable = getFocusable(container)
+        target2 = focusable[0] || container
+      }
+      target2.focus()
+    })
+  }
+
+  function release() {
+    if (!active.value) return
+    active.value = false
+    document.removeEventListener('keydown', onKeydown, true)
+    if (restoreFocus && previouslyFocused && typeof previouslyFocused.focus === 'function') {
+      previouslyFocused.focus()
+    }
+    previouslyFocused = null
+    container = null
+  }
+
+  onBeforeUnmount(() => {
+    release()
+  })
+
+  return {
+    trap,
+    release,
+    active,
+  }
+}

--- a/src/composables/useLiveAnnouncer.ts
+++ b/src/composables/useLiveAnnouncer.ts
@@ -1,0 +1,109 @@
+/**
+ * useLiveAnnouncer — single-instance screen-reader live region announcer.
+ *
+ * Writes text into two visually-hidden `aria-live` regions managed by
+ * `A11yProvider`:
+ *   - polite  (announced when the reader is idle)
+ *   - assertive (announced immediately, interrupts)
+ *
+ * Throttling rules:
+ *   - Identical text within `DEDUP_MS` (500ms) is suppressed.
+ *   - Progress-style messages (opt in via `progress: true`) are rate-limited to
+ *     once per `PROGRESS_INTERVAL_MS` (1s) regardless of content.
+ *
+ * The regions themselves are created once in `A11yProvider.vue`; this module
+ * caches references to them so any composable can announce without props.
+ */
+
+const POLITE_REGION_ID = 'a11y-live-polite'
+const ASSERTIVE_REGION_ID = 'a11y-live-assertive'
+const DEDUP_MS = 500
+const PROGRESS_INTERVAL_MS = 1000
+
+export type LivePoliteness = 'polite' | 'assertive'
+
+export interface AnnounceOptions {
+  /** Assertive announcements interrupt the screen reader; polite waits. */
+  assertive?: boolean
+  /**
+   * Mark progress updates (percentages, "downloading…") so they are throttled
+   * to at most once per second regardless of how often they fire.
+   */
+  progress?: boolean
+}
+
+interface LiveAnnouncer {
+  announce: (text: string, options?: AnnounceOptions) => void
+  announcePolite: (text: string, options?: Omit<AnnounceOptions, 'assertive'>) => void
+  announceAssertive: (text: string, options?: Omit<AnnounceOptions, 'assertive'>) => void
+}
+
+function getRegion(id: string): HTMLElement | null {
+  if (typeof document === 'undefined') return null
+  return document.getElementById(id)
+}
+
+/**
+ * The live region must be cleared and re-set for some screen readers to
+ * re-announce identical or near-identical text. We toggle the textContent
+ * through an empty string on a microtask to force a re-announcement.
+ */
+function writeRegion(region: HTMLElement | null, text: string) {
+  if (!region) return
+  region.textContent = ''
+  // Force the empty state to be observed before setting the new text.
+  requestAnimationFrame(() => {
+    if (region) region.textContent = text
+  })
+}
+
+function createAnnouncer(): LiveAnnouncer {
+  let lastText = ''
+  let lastAt = 0
+  let lastProgressAt = 0
+
+  function announce(text: string, options: AnnounceOptions = {}) {
+    const trimmed = (text || '').trim()
+    if (!trimmed) return
+    const now = Date.now()
+
+    if (options.progress) {
+      if (now - lastProgressAt < PROGRESS_INTERVAL_MS) return
+      lastProgressAt = now
+    } else if (trimmed === lastText && now - lastAt < DEDUP_MS) {
+      return
+    }
+
+    lastText = trimmed
+    lastAt = now
+
+    const region = getRegion(options.assertive ? ASSERTIVE_REGION_ID : POLITE_REGION_ID)
+    writeRegion(region, trimmed)
+  }
+
+  return {
+    announce,
+    announcePolite: (text, options = {}) => announce(text, { ...options, assertive: false }),
+    announceAssertive: (text, options = {}) => announce(text, { ...options, assertive: true }),
+  }
+}
+
+// Singleton: one announcer for the whole app. The live regions live in the DOM
+// (mounted by A11yProvider), so a module-level instance is safe.
+let singleton: LiveAnnouncer | null = null
+
+function getAnnouncer(): LiveAnnouncer {
+  if (!singleton) singleton = createAnnouncer()
+  return singleton
+}
+
+/** Public composable. Returns the singleton announcer. */
+export function useLiveAnnouncer(): LiveAnnouncer {
+  return getAnnouncer()
+}
+
+/** IDs used by A11yProvider to mount the live regions. Exported for symmetry. */
+export const LIVE_REGION_IDS = {
+  polite: POLITE_REGION_ID,
+  assertive: ASSERTIVE_REGION_ID,
+} as const

--- a/src/composables/useRovingTabindex.ts
+++ b/src/composables/useRovingTabindex.ts
@@ -1,0 +1,148 @@
+import { onBeforeUnmount, ref, watch, type Ref } from 'vue'
+
+/**
+ * useRovingTabindex — roving tabindex keyboard navigation for a container of
+ * sibling items (toolbars, tab lists, track rows, tree views).
+ *
+ * Exactly one item carries `tabindex="0"` (the "active" one, reachable with a
+ * single Tab from outside the container); every other item gets `tabindex="-1"`
+ * and is reachable only via arrow/Home/End keys while the container has focus.
+ *
+ * This implements the WAI-ARIA patterns for:
+ *   - horizontal (Left/Right)
+ *   - vertical (Up/Down)
+ *   - grid (all four arrows)
+ *
+ * Usage:
+ *   const items = ref<HTMLElement[]>([])
+ *   const rove = useRovingTabindex(items, { orientation: 'vertical' })
+ *   // bind: :tabindex="rove.tabindexOf(el)"  @keydown="rove.onKeydown"
+ *   rove.activate(2) // move roving focus to index 2
+ */
+
+export type RovingOrientation = 'horizontal' | 'vertical' | 'grid'
+
+export interface RovingTabindexOptions {
+  orientation?: RovingOrientation
+  /** Whether to wrap arrow navigation from last→first and vice versa. Default true. */
+  wrap?: boolean
+  /** Called with the new active index whenever it changes (e.g. to sync selection). */
+  onActivate?: (index: number) => void
+}
+
+export interface RovingTabindexHandle {
+  /** Index of the item that currently holds tabindex=0. */
+  activeIndex: Ref<number>
+  /** Set tabindex for an item: 0 for the active one, -1 otherwise. */
+  tabindexOf: (index: number) => 0 | -1
+  /** Move the roving focus to `index` and focus the element. */
+  activate: (index: number) => void
+  /** Move focus by a delta (clamped/wrapped). */
+  move: (delta: number) => void
+  /** Keydown handler to attach to each item (or the container). */
+  onKeydown: (event: KeyboardEvent, index: number) => void
+}
+
+function clampWrap(index: number, count: number, wrap: boolean): number {
+  if (count === 0) return 0
+  if (wrap) {
+    return ((index % count) + count) % count
+  }
+  return Math.max(0, Math.min(index, count - 1))
+}
+
+export function useRovingTabindex(
+  items: Ref<HTMLElement[] | ReadonlyArray<HTMLElement>>,
+  options: RovingTabindexOptions = {},
+): RovingTabindexHandle {
+  const { orientation = 'horizontal', wrap = true, onActivate } = options
+  const activeIndex = ref(0)
+
+  function count() {
+    return items.value.length
+  }
+
+  function focusIndex(index: number) {
+    const list = items.value
+    const clamped = clampWrap(index, count(), wrap)
+    activeIndex.value = clamped
+    const el = list[clamped]
+    if (el && typeof el.focus === 'function') {
+      el.focus()
+    }
+    onActivate?.(clamped)
+  }
+
+  function tabindexOf(index: number): 0 | -1 {
+    return index === activeIndex.value ? 0 : -1
+  }
+
+  function activate(index: number) {
+    focusIndex(index)
+  }
+
+  function move(delta: number) {
+    focusIndex(activeIndex.value + delta)
+  }
+
+  function onKeydown(event: KeyboardEvent, index: number) {
+    const isHorizontal = orientation === 'horizontal' || orientation === 'grid'
+    const isVertical = orientation === 'vertical' || orientation === 'grid'
+    const count2 = count()
+    if (count2 === 0) return
+
+    let handled = false
+    switch (event.key) {
+      case 'ArrowRight':
+        if (isHorizontal) { move(1); handled = true }
+        break
+      case 'ArrowLeft':
+        if (isHorizontal) { move(-1); handled = true }
+        break
+      case 'ArrowDown':
+        if (isVertical) { move(1); handled = true }
+        break
+      case 'ArrowUp':
+        if (isVertical) { move(-1); handled = true }
+        break
+      case 'Home':
+        focusIndex(0); handled = true
+        break
+      case 'End':
+        focusIndex(count2 - 1); handled = true
+        break
+      default:
+        break
+    }
+    if (handled) {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+  }
+
+  // Keep activeIndex inside bounds when the item list shrinks.
+  watch(() => items.value.length, (len) => {
+    if (activeIndex.value >= len && len > 0) {
+      activeIndex.value = len - 1
+    } else if (len === 0) {
+      activeIndex.value = 0
+    }
+  })
+
+  onBeforeUnmount(() => {
+    activeIndex.value = 0
+  })
+
+  return {
+    activeIndex,
+    tabindexOf,
+    activate,
+    move,
+    onKeydown,
+  }
+}
+
+/** Convenience: a plain array of tabindex values for a known item count. */
+export function rovingTabindexList(activeIndex: number, count: number): number[] {
+  return Array.from({ length: count }, (_, i) => (i === activeIndex ? 0 : -1))
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3,6 +3,10 @@
     "name": "Pymss Studio",
     "bootPreparing": "Initializing workspace..."
   },
+  "a11y": {
+    "skipToContent": "Skip to main content",
+    "primaryNav": "Primary"
+  },
   "nav": {
     "separate": "Separate",
     "models": "Models",
@@ -12,6 +16,7 @@
     "settings": "Settings",
     "workflows": "Workflows",
     "workflow-node-editor": "Node Editor",
+    "simple": "Simple",
     "debug": "Debug"
   },
   "common": {
@@ -1259,5 +1264,46 @@
     "createNodePanelHint": "Pick a node type — the new node will be connected to this link automatically.",
     "collapseNode": "Collapse node",
     "expandNode": "Expand node"
+  },
+  "simple": {
+    "pageTitle": "Simple Mode",
+    "intro": "This is a streamlined separation page designed for screen reader users. Pick a model, add audio files, start separation, and preview results with native audio controls.",
+    "backToMain": "Back to main",
+    "modeTitle": "Operation mode",
+    "modeModel": "Model separation",
+    "modeWorkflow": "Workflow separation",
+    "modelTitle": "Choose a model",
+    "modelLabel": "Separation model",
+    "noModelsHint": "No models downloaded yet. Go to the Models page to download one first.",
+    "workflowTitle": "Choose a workflow",
+    "workflowLabel": "Workflow",
+    "noWorkflowsHint": "No workflows created yet.",
+    "filesTitle": "Audio files",
+    "addFiles": "Add audio files",
+    "removeFile": "Remove {name}",
+    "noFiles": "Please add audio files first",
+    "noFilesHint": "Click the button above to pick audio or video files.",
+    "filesAdded": "Added {count} file(s)",
+    "fileRemoved": "Removed {name}",
+    "startTitle": "Start separation",
+    "startSeparation": "Start separation",
+    "starting": "Starting…",
+    "started": "Started {count} separation task(s)",
+    "partialSuccess": "{succeeded} succeeded, {failed} failed",
+    "noModelSelected": "Please select a model first",
+    "noWorkflowSelected": "Please select a workflow first",
+    "progressTitle": "In progress",
+    "taskProgress": "Progress {percent}%, {stage}",
+    "taskDone": "Done",
+    "taskFailed": "Failed",
+    "taskCancelled": "Cancelled",
+    "taskDoneAnnounce": "{name} separation complete",
+    "taskFailedAnnounce": "{name} separation failed",
+    "resultsTitle": "Results",
+    "openOutputDir": "Open output folder",
+    "openOutput": "Open output folder for {name}",
+    "previewStem": "Preview {stem}",
+    "audioNotSupported": "Your browser does not support audio playback.",
+    "noOutputs": "This task has no output files yet."
   }
 }

--- a/src/i18n/zh-CN.json
+++ b/src/i18n/zh-CN.json
@@ -3,6 +3,10 @@
     "name": "Pymss Studio",
     "bootPreparing": "正在初始化工作环境…"
   },
+  "a11y": {
+    "skipToContent": "跳到主内容",
+    "primaryNav": "主导航"
+  },
   "nav": {
     "separate": "分离",
     "models": "模型",
@@ -12,6 +16,7 @@
     "settings": "设置",
     "workflows": "工作流",
     "workflow-node-editor": "节点编辑器",
+    "simple": "简化操作",
     "debug": "调试"
   },
   "common": {
@@ -1259,5 +1264,46 @@
     "createNodePanelHint": "选择要创建的节点类型，新节点会自动与当前连线相连。",
     "collapseNode": "折叠节点",
     "expandNode": "展开节点"
+  },
+  "simple": {
+    "pageTitle": "简化操作",
+    "intro": "这是一个为读屏用户设计的精简分离页面。按步骤选择模型、添加音频文件、开始分离，即可用原生音频控件预览结果。",
+    "backToMain": "返回主界面",
+    "modeTitle": "操作模式",
+    "modeModel": "模型分离",
+    "modeWorkflow": "工作流分离",
+    "modelTitle": "选择模型",
+    "modelLabel": "分离模型",
+    "noModelsHint": "尚未下载任何模型，请先到模型页下载。",
+    "workflowTitle": "选择工作流",
+    "workflowLabel": "工作流",
+    "noWorkflowsHint": "尚未创建工作流。",
+    "filesTitle": "音频文件",
+    "addFiles": "添加音频文件",
+    "removeFile": "移除 {name}",
+    "noFiles": "请先添加音频文件",
+    "noFilesHint": "点击上方按钮选择音频或视频文件。",
+    "filesAdded": "已添加 {count} 个文件",
+    "fileRemoved": "已移除 {name}",
+    "startTitle": "开始分离",
+    "startSeparation": "开始分离",
+    "starting": "正在启动…",
+    "started": "已开始 {count} 个分离任务",
+    "partialSuccess": "{succeeded} 个成功，{failed} 个失败",
+    "noModelSelected": "请先选择一个模型",
+    "noWorkflowSelected": "请先选择一个工作流",
+    "progressTitle": "进行中",
+    "taskProgress": "进度 {percent}%，{stage}",
+    "taskDone": "已完成",
+    "taskFailed": "失败",
+    "taskCancelled": "已取消",
+    "taskDoneAnnounce": "{name} 分离完成",
+    "taskFailedAnnounce": "{name} 分离失败",
+    "resultsTitle": "结果",
+    "openOutputDir": "打开输出目录",
+    "openOutput": "打开 {name} 的输出目录",
+    "previewStem": "预览 {stem}",
+    "audioNotSupported": "您的浏览器不支持音频播放。",
+    "noOutputs": "此任务暂无输出文件。"
   }
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
+import i18n from '@/i18n'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -13,8 +14,42 @@ const router = createRouter({
     { path: '/debug', name: 'debug', component: () => import('@/views/DebugView.vue') },
     { path: '/projects', redirect: { name: 'results' } },
     { path: '/editor', name: 'editor', component: () => import('@/views/EditorView.vue') },
+    { path: '/simple', name: 'simple', component: () => import('@/views/SimpleView.vue') },
     { path: '/settings', name: 'settings', component: () => import('@/views/SettingsView.vue') },
   ],
+})
+
+const APP_NAME = 'Pymss Studio'
+
+function routeTitle(routeName: unknown): string {
+  if (typeof routeName !== 'string') return APP_NAME
+  // The nav namespace carries a label for every route name; fall back to the
+  // raw name if a translation is missing (vue-i18n returns the key itself).
+  const label = i18n.global.t(`nav.${routeName}`)
+  return label === `nav.${routeName}` ? APP_NAME : `${label} · ${APP_NAME}`
+}
+
+// After every navigation: move keyboard focus to the main content region so
+// screen-reader users land on the new page instead of staying in the sidebar,
+// and sync document.title so the reader announces the new page by name.
+router.afterEach((to) => {
+  if (typeof document === 'undefined') return
+  document.title = routeTitle(to.name)
+
+  // Defer the focus move until the new view has mounted. requestAnimationFrame
+  // runs after Vue's navigation resolve + DOM patch for the hash router.
+  requestAnimationFrame(() => {
+    const main = document.getElementById('main-content')
+    if (main) {
+      // Focus the region itself (tabindex=-1 makes it programmatically focusable
+      // without adding it to the Tab order). Only steal focus when focus is not
+      // already inside the main region, so we don't disrupt in-page focus.
+      const active = document.activeElement
+      if (!active || !main.contains(active)) {
+        main.focus({ preventScroll: true })
+      }
+    }
+  })
 })
 
 export default router

--- a/src/stores/task.ts
+++ b/src/stores/task.ts
@@ -9,6 +9,15 @@ import { useAppStore } from '@/stores/app'
 import type { WorkflowEntry } from '@/stores/workflow'
 import { getWorkflowBatchInputConfigs, getWorkflowValidationSummary, stripWorkflowUi, workflowValidationErrorMessage, type WorkflowValidationSummary } from '@/utils/workflowDefinition'
 import { getWorkflowDefinitionDefaults, readWorkflowGraphDefinition, serializeWorkflowGraphDefinition } from '@/utils/workflowGraph'
+import { useLiveAnnouncer } from '@/composables/useLiveAnnouncer'
+
+// Screen-reader announcement helper for task lifecycle events.
+// The announcer is a DOM-only singleton; safe to call from the store.
+const liveAnnouncer = useLiveAnnouncer()
+function announceTaskEvent(text: string, assertive = false) {
+  if (assertive) liveAnnouncer.announceAssertive(text)
+  else liveAnnouncer.announcePolite(text)
+}
 
 export type TaskStatus = 'queued' | 'preparing' | 'validating_input' | 'downloading_model' | 'ensuring_model' | 'loading_model' | 'separating' | 'writing_output' | 'done' | 'failed' | 'cancelled'
 
@@ -1360,6 +1369,10 @@ export const useTaskStore = defineStore('task', () => {
       }
       if (!recoverable) markTaskFinished(task)
       appendTaskLogs(task, [`error: ${code}${message}`, detail ? `traceback:\n${detail}` : ''])
+      // Announce failure to screen readers (assertive — interrupts).
+      if (!recoverable) {
+        announceTaskEvent(i18n.global.t('simple.taskFailedAnnounce', { name: task.input.split(/[/\\]/).pop() || task.input }), true)
+      }
     } else if (event.type === 'task_done') {
       task.status = 'done'
       markTaskStarted(task)
@@ -1377,6 +1390,8 @@ export const useTaskStore = defineStore('task', () => {
       task.outputs = event.payload?.outputs?.length
         ? event.payload.outputs
         : outputsFromFiles(task.output, task.files, event.payload?.outputFormat || 'wav', task.outputPrefix)
+      // Announce completion to screen readers.
+      announceTaskEvent(i18n.global.t('simple.taskDoneAnnounce', { name: task.input.split(/[/\\]/).pop() || task.input }))
       task.error = undefined
       touch(task)
       markTaskFinished(task, task.updatedAt)

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -65,6 +65,51 @@ body {
 button, input, select, textarea { font: inherit; }
 a { color: inherit; text-decoration: none; }
 
+/* ===== Accessible Focus Ring =====
+ * A single visible focus indicator for keyboard navigation across the whole app.
+ * `:focus-visible` only triggers on keyboard focus, so mouse clicks keep their
+ * clean look. The ring uses the primary token so it stays visible on both the
+ * dark and light themes. */
+:where(a, button, input, select, textarea, summary, [tabindex], [contenteditable="true"]):focus-visible {
+  outline: 2px solid var(--primary-strong);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+/* Some custom controls render focusable surfaces that the generic rule above
+ * cannot reach (role=button on a div, or icon-only chips that paint their own
+ * background). Give them the same ring explicitly. */
+:where(.nav-item, .transport-chip, .transport-play, .chip, .track-row, .onboarding-chip, .onboarding-accent-card, .onboarding-runtime-card):focus-visible {
+  outline: 2px solid var(--primary-strong);
+  outline-offset: 2px;
+}
+
+/* Skip-to-content link: visually hidden until focused, then pinned to the
+ * top-left so keyboard users can bypass the sidebar on every page. */
+.skip-link {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 10000;
+  padding: 8px 14px;
+  border-radius: 10px;
+  background: var(--primary);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  box-shadow: var(--shadow-soft);
+  /* Hidden until keyboard focus arrives. */
+  transform: translateY(-150%);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 160ms ease, opacity 160ms ease;
+}
+.skip-link:focus-visible {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
 /* ===== App Shell ===== */
 .app-shell {
   width: 100vw;

--- a/src/views/ModelsView.vue
+++ b/src/views/ModelsView.vue
@@ -866,6 +866,7 @@ onMounted(() => {
               'model-card--busy': isModelBusy(model)
             }]"
             tabindex="0"
+            role="button"
             :aria-label="t('models.viewDetailAria', { name: model.name })"
             :aria-current="selectedModel === model.name ? 'true' : undefined"
             @click="selectModel(model)"
@@ -1030,7 +1031,7 @@ onMounted(() => {
     </div>
 
     <!-- Detail Modal -->
-    <n-modal :show="showDetail" @update:show="handleDetailDrawerUpdate" @after-leave="handleDetailModalAfterLeave">
+    <n-modal :show="showDetail" :close-on-esc="true" @update:show="handleDetailDrawerUpdate" @after-leave="handleDetailModalAfterLeave">
       <n-card
         class="model-detail-modal"
         :title="t('models.detail')"
@@ -1038,6 +1039,7 @@ onMounted(() => {
         closable
         role="dialog"
         aria-modal="true"
+        :aria-label="t('models.detail')"
         @close="handleDetailDrawerUpdate(false)"
       >
         <template v-if="selectedInfo">

--- a/src/views/ResultsView.vue
+++ b/src/views/ResultsView.vue
@@ -484,6 +484,7 @@ function formatDurationMs(value: number | undefined) {
         class="results-toolbar__search"
         clearable
         :placeholder="t('results.searchPlaceholder')"
+        :aria-label="t('results.searchPlaceholder')"
       >
         <template #prefix><n-icon :component="SearchOutline" /></template>
       </n-input>
@@ -493,6 +494,7 @@ function formatDurationMs(value: number | undefined) {
         class="results-toolbar__sort"
         size="small"
         :options="sortOptions"
+        aria-label="Sort results"
       >
         <template #arrow><n-icon :component="SwapVerticalOutline" /></template>
       </n-select>
@@ -532,12 +534,13 @@ function formatDurationMs(value: number | undefined) {
       <span>{{ t('results.noMatchHint') }}</span>
     </div>
 
-    <div v-else class="results-list">
+    <div v-else class="results-list" role="list" :aria-label="t('results.title')">
       <section
         v-for="item in pagedResults"
         :id="resultCardId(item)"
         :key="item.id"
         class="result-row"
+        role="listitem"
         :class="{ 'result-row--selectable': selecting, 'result-row--selected': selectedResultSet.has(item.id) }"
       >
         <n-checkbox
@@ -570,15 +573,15 @@ function formatDurationMs(value: number | undefined) {
         </button>
 
         <div v-if="!selecting" class="result-row__actions">
-          <n-button v-if="item.inputCount === 1" size="small" type="primary" @click.stop="openInEditor(item.primary)">
+          <n-button v-if="item.inputCount === 1" size="small" type="primary" :aria-label="t('results.openInEditor')" @click.stop="openInEditor(item.primary)">
             <template #icon><n-icon :component="ColorWandOutline" /></template>
             {{ t('results.openInEditor') }}
           </n-button>
-          <n-button size="small" type="primary" secondary @click.stop="openResultDir(item)">
+          <n-button size="small" type="primary" secondary :aria-label="t('results.openDirectory')" @click.stop="openResultDir(item)">
             <template #icon><n-icon :component="FolderOpenOutline" /></template>
             {{ t('results.openDirectory') }}
           </n-button>
-          <n-button size="small" quaternary type="error" @click.stop="handleRemoveResult(item)">
+          <n-button size="small" quaternary type="error" :aria-label="t('results.removeAction')" @click.stop="handleRemoveResult(item)">
             <template #icon><n-icon :component="TrashOutline" /></template>
             {{ t('results.removeAction') }}
           </n-button>
@@ -597,11 +600,11 @@ function formatDurationMs(value: number | undefined) {
                   <span>{{ result.outputs.length }} {{ t('results.stemUnit') }} · {{ formatDurationMs(taskDurationMs(result)) }}</span>
                 </div>
                 <div class="result-detail-card__actions">
-                  <n-button size="tiny" secondary @click.stop="openInEditor(result)">
+                  <n-button size="tiny" secondary :aria-label="t('results.openInEditor')" @click.stop="openInEditor(result)">
                     <template #icon><n-icon :component="ColorWandOutline" /></template>
                     {{ t('results.openInEditor') }}
                   </n-button>
-                  <n-button size="tiny" tertiary @click.stop="task.revealPath(result.outputs[0]?.path || result.output)">
+                  <n-button size="tiny" tertiary :aria-label="t('results.openDirectory')" @click.stop="task.revealPath(result.outputs[0]?.path || result.output)">
                     <template #icon><n-icon :component="FolderOpenOutline" /></template>
                     {{ t('results.openDirectory') }}
                   </n-button>

--- a/src/views/SeparateView.vue
+++ b/src/views/SeparateView.vue
@@ -1563,7 +1563,11 @@ async function retryCurrentTask() {
             <div
               class="dropzone"
               :class="{ 'dropzone--dragging': isDragging, 'dropzone--filled': inputFiles.length, 'dropzone--clickable': !inputFiles.length && !isRunModeLocked }"
+              role="button"
+              tabindex="0"
+              :aria-label="t('separate.chooseFiles')"
               @click="(!inputFiles.length && !isRunModeLocked) ? handlePickFiles() : undefined"
+              @keydown.enter="(!inputFiles.length && !isRunModeLocked) ? handlePickFiles() : undefined"
             >
               <div v-if="inputFiles.length" class="file-list">
                 <div
@@ -2026,7 +2030,7 @@ async function retryCurrentTask() {
       </main>
     </div>
 
-    <n-modal v-model:show="showEnsembleModal" :mask-closable="true">
+    <n-modal v-model:show="showEnsembleModal" :mask-closable="true" :close-on-esc="true">
       <n-card
         class="ensemble-modal"
         :title="t('separate.ensembleConfigureTitle')"
@@ -2034,6 +2038,7 @@ async function retryCurrentTask() {
         closable
         role="dialog"
         aria-modal="true"
+        :aria-label="t('separate.ensembleConfigureTitle')"
         @close="showEnsembleModal = false"
       >
         <div class="ensemble-modal__intro">
@@ -2079,6 +2084,7 @@ async function retryCurrentTask() {
         closable
         role="dialog"
         aria-modal="true"
+        :aria-label="t('separate.settingsDrawerTitle')"
         @close="showSettingsDrawer = false"
       >
         <div class="settings-drawer__content">
@@ -2216,6 +2222,7 @@ async function retryCurrentTask() {
         closable
         role="dialog"
         aria-modal="true"
+        :aria-label="t('separate.namingModalTitle')"
         @close="showNamingModal = false"
       >
         <div class="naming-modal__content">
@@ -2313,6 +2320,7 @@ async function retryCurrentTask() {
         size="small"
         role="dialog"
         aria-modal="true"
+        :aria-label="t('tasks.logs')"
       >
         <div v-if="currentTask?.logs.length" class="log-console">
           <div v-for="(line, index) in currentTask.logs" :key="`${index}-${line}`" class="log-line">

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -2,7 +2,7 @@
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useDialog, useMessage } from 'naive-ui'
 import { invoke } from '@tauri-apps/api/core'
 import { open } from '@tauri-apps/plugin-shell'
@@ -62,6 +62,7 @@ const { t, locale: currentLocale } = useI18n()
 const message = useMessage()
 const dialog = useDialog()
 const route = useRoute()
+const router = useRouter()
 const settings = useSettingsStore()
 const app = useAppStore()
 const updates = useUpdateStore()
@@ -1151,6 +1152,7 @@ onMounted(async () => {
                 :options="updateChannelOptions"
                 :disabled="!updateSupported || updates.isBusy"
                 size="small"
+                aria-label="Update channel"
                 @update:value="changeUpdateChannel"
               />
               <p class="update-panel__notes update-panel__notes--muted">{{ updateChannel === 'prerelease' ? t('settings.updateChannelPrereleaseHint') : t('settings.updateChannelStableHint') }}</p>
@@ -1222,6 +1224,16 @@ onMounted(async () => {
                   <n-icon class="about-link-item__open" :component="OpenOutline" size="16" />
                 </button>
               </div>
+            </article>
+
+            <article class="about-info-card about-info-card--accessibility">
+              <div class="section-title section-title--plain">
+                <span>{{ t('simple.pageTitle') }}</span>
+              </div>
+              <p class="appearance-hint">{{ t('simple.intro') }}</p>
+              <n-button secondary size="small" @click="router.push('/simple')">
+                {{ t('simple.pageTitle') }}
+              </n-button>
             </article>
           </div>
         </section>
@@ -1311,6 +1323,7 @@ onMounted(async () => {
                     :value="locale"
                     :options="languageOptions"
                     :consistent-menu-width="false"
+                    :aria-label="t('settings.language')"
                     @update:value="selectLocale"
                   />
                 </div>
@@ -1338,6 +1351,7 @@ onMounted(async () => {
                     :step="1"
                     :marks="scaleSliderMarks"
                     :tooltip="false"
+                    :aria-label="t('settings.scaleFactor')"
                   />
                   <span class="scale-value">{{ scaleFactorPercent }}</span>
                 </div>
@@ -1350,7 +1364,7 @@ onMounted(async () => {
                 <p class="setting-row__hint">{{ t('settings.animationsHint') }}</p>
               </div>
               <div class="setting-row__control">
-                <n-switch v-model:value="animationsEnabled" />
+                <n-switch v-model:value="animationsEnabled" :aria-label="t('settings.animations')" />
               </div>
             </div>
           </div>
@@ -1552,7 +1566,7 @@ onMounted(async () => {
 
             <div class="runtime-mirror-row">
               <label class="text-muted text-sm">{{ t('settings.runtimeMirrorLabel') }}</label>
-              <n-select v-model:value="runtimeMirror" size="small" class="runtime-mirror-row__select" :options="[
+              <n-select v-model:value="runtimeMirror" size="small" class="runtime-mirror-row__select" :aria-label="t('settings.runtimeMirrorLabel')" :options="[
                 { label: t('onboarding.runtimeMirrorAuto'), value: 'auto' },
                 { label: t('onboarding.runtimeMirrorUstc'), value: 'ustc' },
                 { label: t('onboarding.runtimeMirrorTsinghua'), value: 'tsinghua' },
@@ -1699,6 +1713,7 @@ onMounted(async () => {
                 <n-select
                   v-model:value="defaultDevice"
                   :options="deviceOptions"
+                  :aria-label="t('settings.defaultDevice')"
                 />
               </div>
             </section>
@@ -1708,6 +1723,7 @@ onMounted(async () => {
                 <label class="text-muted text-sm">{{ t('settings.downloadSource') }}</label>
                 <n-select
                   v-model:value="downloadSource"
+                  :aria-label="t('settings.downloadSource')"
                   :options="[
                     { label: 'ModelScope', value: 'modelscope' },
                     { label: 'Hugging Face', value: 'huggingface' },
@@ -1720,6 +1736,7 @@ onMounted(async () => {
                 <n-select
                   v-model:value="downloadMethod"
                   :options="downloadMethodOptions"
+                  :aria-label="t('settings.downloadMethod')"
                 />
                 <p class="text-muted text-sm setting-field__hint">{{ t('settings.downloadMethodHint') }}</p>
               </div>
@@ -1731,6 +1748,7 @@ onMounted(async () => {
                 <n-select
                   v-model:value="proxyMode"
                   :options="proxyModeOptions"
+                  :aria-label="t('settings.proxyMode')"
                   @update:value="resetProxyTest"
                 />
                 <p class="text-muted text-sm setting-field__hint">{{ t('settings.proxyModeHint') }}</p>
@@ -1743,6 +1761,7 @@ onMounted(async () => {
                     :placeholder="t('settings.proxyUrlPlaceholder')"
                     clearable
                     size="small"
+                    :aria-label="t('settings.proxyUrl')"
                     @update:value="resetProxyTest"
                   />
                 </div>
@@ -1752,6 +1771,7 @@ onMounted(async () => {
                     v-model:value="proxyBypass"
                     :placeholder="t('settings.proxyBypassPlaceholder')"
                     size="small"
+                    :aria-label="t('settings.proxyBypass')"
                   />
                 </div>
               </div>
@@ -1811,6 +1831,7 @@ onMounted(async () => {
                   :step="1"
                   clearable
                   style="width: 100%;"
+                  :aria-label="t('settings.maxConcurrentSeparations')"
                 />
                 <p class="text-muted text-sm setting-field__hint">
                   {{ t('settings.maxConcurrentSeparationsHint') }}
@@ -1833,7 +1854,7 @@ onMounted(async () => {
                       {{ t('settings.developerModeHint') }}
                     </p>
                   </div>
-                  <n-switch v-model:value="developerMode" />
+                  <n-switch v-model:value="developerMode" :aria-label="t('settings.developerModeTitle')" />
                 </div>
               </div>
             </section>

--- a/src/views/SimpleView.vue
+++ b/src/views/SimpleView.vue
@@ -1,0 +1,693 @@
+<script setup lang="ts">
+/**
+ * SimpleView — a screen-reader-first separation page.
+ *
+ * The main SeparateView is a rich, visual, drag-and-drop workspace. This view
+ * strips it down to a single linear flow that works end-to-end with keyboard
+ * and screen reader alone:
+ *
+ *   1. Choose a model (or workflow)
+ *   2. Add audio files
+ *   3. Start separation
+ *   4. Preview results with native <audio controls>
+ *   5. Export / open output folder
+ *
+ * It reuses the same stores (task, model, workflow, settings) so no business
+ * logic is duplicated. Every action is announced via useLiveAnnouncer.
+ */
+import { computed, onMounted, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import { useMessage } from 'naive-ui'
+import { convertFileSrc } from '@tauri-apps/api/core'
+import {
+  ArrowBackOutline,
+  AddCircleOutline,
+  CloseCircleOutline,
+  PlayCircleOutline,
+  DownloadOutline,
+  FolderOpenOutline,
+  CubeOutline,
+  GitNetworkOutline,
+  SettingsOutline,
+} from '@vicons/ionicons5'
+import { useTaskStore, type SeparationTask } from '@/stores/task'
+import { useModelStore } from '@/stores/model'
+import { useWorkflowStore } from '@/stores/workflow'
+import { useSettingsStore } from '@/stores/settings'
+import { useLiveAnnouncer } from '@/composables/useLiveAnnouncer'
+import SrText from '@/components/SrText.vue'
+
+const { t } = useI18n()
+const router = useRouter()
+const message = useMessage()
+const task = useTaskStore()
+const model = useModelStore()
+const workflow = useWorkflowStore()
+const settings = useSettingsStore()
+const announcer = useLiveAnnouncer()
+
+const { inputFiles, separateRunMode: runMode } = storeToRefs(task)
+const { selectedModel, downloadedModels, models: modelEntries } = storeToRefs(model)
+const { workflows, selectedWorkflow, selectedWorkflowId } = storeToRefs(workflow)
+
+type Mode = 'model' | 'workflow'
+const mode = ref<Mode>('model')
+
+// ---- Model options ----
+const modelOptions = computed(() => {
+  return downloadedModels.value.map((m) => ({
+    label: m.name,
+    value: m.name,
+  }))
+})
+
+// ---- Workflow options ----
+const workflowOptions = computed(() => {
+  return workflows.value.map((w) => ({
+    label: w.name,
+    value: w.id,
+  }))
+})
+
+// ---- File list ----
+const fileList = computed(() => inputFiles.value)
+
+function fileName(path: string) {
+  return path.split(/[/\\]/).pop() || path
+}
+
+async function addFiles() {
+  const before = inputFiles.value.length
+  await task.pickFiles()
+  const added = inputFiles.value.length - before
+  if (added > 0) {
+    message.success(t('simple.filesAdded', { count: added }))
+    announcer.announcePolite(t('simple.filesAdded', { count: added }))
+  }
+}
+
+function removeFile(index: number) {
+  const file = inputFiles.value[index]
+  if (!file) return
+  task.removeInputFile(file)
+  announcer.announcePolite(t('simple.fileRemoved', { name: fileName(file) }))
+}
+
+// ---- Mode switching ----
+function switchMode(newMode: Mode) {
+  mode.value = newMode
+  runMode.value = newMode
+  announcer.announcePolite(newMode === 'workflow' ? t('simple.modeWorkflow') : t('simple.modeModel'))
+}
+
+// ---- Start separation ----
+const isStarting = ref(false)
+
+async function startSeparation() {
+  if (mode.value === 'model' && !selectedModel.value) {
+    message.warning(t('simple.noModelSelected'))
+    announcer.announceAssertive(t('simple.noModelSelected'))
+    return
+  }
+  if (mode.value === 'workflow' && !selectedWorkflow.value) {
+    message.warning(t('simple.noWorkflowSelected'))
+    announcer.announceAssertive(t('simple.noWorkflowSelected'))
+    return
+  }
+  if (!inputFiles.value.length) {
+    message.warning(t('simple.noFiles'))
+    announcer.announceAssertive(t('simple.noFiles'))
+    return
+  }
+  isStarting.value = true
+  announcer.announcePolite(t('simple.starting'))
+  try {
+    const result = mode.value === 'workflow' && selectedWorkflow.value
+      ? await task.startWorkflowInference(selectedWorkflow.value, { outputLayout: 'flat' })
+      : await task.startSeparation({ outputLayout: 'flat' })
+    if (result && result.failed > 0) {
+      message.warning(t('simple.partialSuccess', { succeeded: result.succeeded, failed: result.failed }))
+      announcer.announcePolite(t('simple.partialSuccess', { succeeded: result.succeeded, failed: result.failed }))
+    } else {
+      message.success(t('simple.started', { count: result?.succeeded ?? 1 }))
+      announcer.announcePolite(t('simple.started', { count: result?.succeeded ?? 1 }))
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    message.error(msg)
+    announcer.announceAssertive(msg)
+  } finally {
+    isStarting.value = false
+  }
+}
+
+// ---- Active tasks (progress) ----
+const activeTasks = computed(() => task.runningTasks)
+const recentDoneTasks = computed(() =>
+  task.completedTasks.slice(0, 10),
+)
+
+function taskProgressText(taskItem: SeparationTask): string {
+  if (taskItem.status === 'done') return t('simple.taskDone')
+  if (taskItem.status === 'failed') return t('simple.taskFailed')
+  if (taskItem.status === 'cancelled') return t('simple.taskCancelled')
+  return t('simple.taskProgress', { percent: taskItem.progress, stage: taskItem.stageLabel })
+}
+
+// Announce progress milestones
+let lastAnnouncedProgress: Record<string, number> = {}
+watch(activeTasks, (tasks) => {
+  tasks.forEach((taskItem) => {
+    const last = lastAnnouncedProgress[taskItem.id] || 0
+    const current = taskItem.progress
+    // Announce at every 25% milestone
+    const milestone = Math.floor(current / 25) * 25
+    if (milestone > last && milestone > 0) {
+      announcer.announcePolite(taskProgressText(taskItem), { progress: true })
+      lastAnnouncedProgress[taskItem.id] = milestone
+    }
+  })
+}, { deep: true })
+
+// Announce task completion/failure
+watch(() => task.runningTasks.length, (newCount, oldCount) => {
+  if (newCount < oldCount) {
+    // A task finished — check recent completions
+    const finished = task.completedTasks[0]
+    if (finished) {
+      if (finished.status === 'done') {
+        announcer.announcePolite(t('simple.taskDoneAnnounce', { name: fileName(finished.input) }))
+      } else if (finished.status === 'failed') {
+        announcer.announceAssertive(t('simple.taskFailedAnnounce', { name: fileName(finished.input) }))
+      }
+    }
+  }
+})
+
+// ---- Results preview ----
+function outputUrl(path: string): string {
+  try {
+    return convertFileSrc(path)
+  } catch {
+    return ''
+  }
+}
+
+async function openOutputDir(taskItem: SeparationTask) {
+  try {
+    await task.revealPath(taskItem.output)
+  } catch (err) {
+    message.error(err instanceof Error ? err.message : String(err))
+  }
+}
+
+// ---- Navigation ----
+function goBack() {
+  router.push('/')
+}
+
+function goSettings() {
+  router.push('/settings')
+}
+
+onMounted(() => {
+  // Ensure models are loaded
+  if (!modelEntries.value.length) {
+    void model.loadModels().catch(() => {})
+  }
+  // Set initial mode
+  runMode.value = mode.value
+})
+</script>
+
+<template>
+  <div class="simple-view page">
+    <!-- Top bar -->
+    <header class="simple-topbar">
+      <n-button quaternary size="small" @click="goBack">
+        <template #icon><n-icon :component="ArrowBackOutline" /></template>
+        {{ t('simple.backToMain') }}
+      </n-button>
+      <h1 class="simple-title">{{ t('simple.pageTitle') }}</h1>
+      <n-button quaternary size="small" @click="goSettings">
+        <template #icon><n-icon :component="SettingsOutline" /></template>
+        {{ t('nav.settings') }}
+      </n-button>
+    </header>
+
+    <p class="simple-intro">{{ t('simple.intro') }}</p>
+
+    <!-- Mode selector -->
+    <section class="simple-section" aria-labelledby="simple-mode-heading">
+      <h2 id="simple-mode-heading" class="simple-section__title">{{ t('simple.modeTitle') }}</h2>
+      <div class="simple-mode-buttons" role="radiogroup" :aria-label="t('simple.modeTitle')">
+        <button
+          type="button"
+          class="simple-mode-btn"
+          role="radio"
+          :aria-checked="mode === 'model'"
+          @click="switchMode('model')"
+        >
+          <n-icon :component="CubeOutline" :size="20" aria-hidden="true" />
+          <span>{{ t('simple.modeModel') }}</span>
+        </button>
+        <button
+          type="button"
+          class="simple-mode-btn"
+          role="radio"
+          :aria-checked="mode === 'workflow'"
+          @click="switchMode('workflow')"
+        >
+          <n-icon :component="GitNetworkOutline" :size="20" aria-hidden="true" />
+          <span>{{ t('simple.modeWorkflow') }}</span>
+        </button>
+      </div>
+    </section>
+
+    <!-- Model / Workflow selection -->
+    <section v-if="mode === 'model'" class="simple-section" aria-labelledby="simple-model-heading">
+      <h2 id="simple-model-heading" class="simple-section__title">{{ t('simple.modelTitle') }}</h2>
+      <label class="simple-label" for="simple-model-select">{{ t('simple.modelLabel') }}</label>
+      <select
+        id="simple-model-select"
+        class="simple-select"
+        :value="selectedModel"
+        @change="model.selectModel(($event.target as HTMLSelectElement).value)"
+      >
+        <option v-for="opt in modelOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+      </select>
+      <p v-if="!modelOptions.length" class="simple-hint">{{ t('simple.noModelsHint') }}</p>
+    </section>
+
+    <section v-else class="simple-section" aria-labelledby="simple-workflow-heading">
+      <h2 id="simple-workflow-heading" class="simple-section__title">{{ t('simple.workflowTitle') }}</h2>
+      <label class="simple-label" for="simple-workflow-select">{{ t('simple.workflowLabel') }}</label>
+      <select
+        id="simple-workflow-select"
+        class="simple-select"
+        :value="selectedWorkflowId"
+        @change="workflow.selectWorkflow(($event.target as HTMLSelectElement).value)"
+      >
+        <option v-for="opt in workflowOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+      </select>
+      <p v-if="!workflowOptions.length" class="simple-hint">{{ t('simple.noWorkflowsHint') }}</p>
+    </section>
+
+    <!-- File list -->
+    <section class="simple-section" aria-labelledby="simple-files-heading">
+      <h2 id="simple-files-heading" class="simple-section__title">{{ t('simple.filesTitle') }}</h2>
+      <button type="button" class="simple-action-btn" @click="addFiles">
+        <n-icon :component="AddCircleOutline" :size="20" aria-hidden="true" />
+        <span>{{ t('simple.addFiles') }}</span>
+      </button>
+
+      <ul v-if="fileList.length" class="simple-file-list" :aria-label="t('simple.filesTitle')">
+        <li v-for="(file, index) in fileList" :key="index" class="simple-file-item">
+          <span class="simple-file-name">{{ fileName(file) }}</span>
+          <button
+            type="button"
+            class="simple-remove-btn"
+            :aria-label="t('simple.removeFile', { name: fileName(file) })"
+            @click="removeFile(index)"
+          >
+            <n-icon :component="CloseCircleOutline" :size="18" aria-hidden="true" />
+            <SrText>{{ t('simple.removeFile', { name: fileName(file) }) }}</SrText>
+          </button>
+        </li>
+      </ul>
+      <p v-else class="simple-hint">{{ t('simple.noFilesHint') }}</p>
+    </section>
+
+    <!-- Start button -->
+    <section class="simple-section" aria-labelledby="simple-start-heading">
+      <h2 id="simple-start-heading" class="simple-section__title">{{ t('simple.startTitle') }}</h2>
+      <button
+        type="button"
+        class="simple-start-btn"
+        :disabled="isStarting || !fileList.length"
+        @click="startSeparation"
+      >
+        <n-icon :component="PlayCircleOutline" :size="22" aria-hidden="true" />
+        <span>{{ isStarting ? t('simple.starting') : t('simple.startSeparation') }}</span>
+      </button>
+    </section>
+
+    <!-- Active tasks / progress -->
+    <section v-if="activeTasks.length" class="simple-section" aria-labelledby="simple-progress-heading">
+      <h2 id="simple-progress-heading" class="simple-section__title">{{ t('simple.progressTitle') }}</h2>
+      <ul class="simple-task-list">
+        <li v-for="taskItem in activeTasks" :key="taskItem.id" class="simple-task-item">
+          <div class="simple-task-info">
+            <strong>{{ fileName(taskItem.input) }}</strong>
+            <span class="simple-task-stage">{{ taskItem.stageLabel }}</span>
+          </div>
+          <div class="simple-task-progress">
+            <progress :value="taskItem.progress" max="100" :aria-label="taskProgressText(taskItem)">{{ taskItem.progress }}%</progress>
+            <span class="simple-task-percent">{{ taskItem.progress }}%</span>
+          </div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- Results -->
+    <section v-if="recentDoneTasks.length" class="simple-section" aria-labelledby="simple-results-heading">
+      <h2 id="simple-results-heading" class="simple-section__title">{{ t('simple.resultsTitle') }}</h2>
+      <ul class="simple-result-list">
+        <li v-for="taskItem in recentDoneTasks" :key="taskItem.id" class="simple-result-item">
+          <div class="simple-result-head">
+            <strong>{{ fileName(taskItem.input) }}</strong>
+            <button
+              type="button"
+              class="simple-open-btn"
+              :aria-label="t('simple.openOutput', { name: fileName(taskItem.input) })"
+              @click="openOutputDir(taskItem)"
+            >
+              <n-icon :component="FolderOpenOutline" :size="18" aria-hidden="true" />
+              <span>{{ t('simple.openOutputDir') }}</span>
+            </button>
+          </div>
+          <ul v-if="taskItem.outputs.length" class="simple-stem-list">
+            <li v-for="output in taskItem.outputs" :key="output.path" class="simple-stem-item">
+              <span class="simple-stem-name">{{ output.stem }}</span>
+              <audio controls :src="outputUrl(output.path)" :aria-label="t('simple.previewStem', { stem: output.stem })">
+                <SrText>{{ t('simple.audioNotSupported') }}</SrText>
+              </audio>
+            </li>
+          </ul>
+          <p v-else class="simple-hint">{{ t('simple.noOutputs') }}</p>
+        </li>
+      </ul>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.simple-view {
+  max-width: 720px;
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+}
+
+.simple-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.simple-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  text-align: center;
+  flex: 1;
+}
+
+.simple-intro {
+  margin: 0;
+  color: var(--on-surface-muted);
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.simple-section {
+  display: grid;
+  gap: 10px;
+}
+
+.simple-section__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.simple-label {
+  font-size: 13px;
+  color: var(--on-surface-muted);
+}
+
+.simple-select {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 11px;
+  border: 1px solid var(--outline);
+  background: var(--surface-1);
+  color: var(--on-surface);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.simple-select:focus-visible {
+  outline: 2px solid var(--primary-strong);
+  outline-offset: 2px;
+}
+
+.simple-hint {
+  margin: 0;
+  color: var(--on-surface-muted);
+  font-size: 13px;
+}
+
+.simple-mode-buttons {
+  display: flex;
+  gap: 10px;
+}
+
+.simple-mode-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--outline);
+  background: var(--surface-1);
+  color: var(--on-surface-muted);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 160ms ease;
+}
+
+.simple-mode-btn:hover {
+  border-color: var(--primary-border);
+  color: var(--on-surface);
+}
+
+.simple-mode-btn[aria-checked="true"] {
+  border-color: var(--primary-border);
+  background: var(--primary-soft);
+  color: var(--primary-strong);
+}
+
+.simple-action-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 11px;
+  border: 1px solid var(--primary-border);
+  background: var(--primary-soft);
+  color: var(--primary-strong);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 160ms ease;
+}
+
+.simple-action-btn:hover {
+  background: color-mix(in srgb, var(--primary-soft) 60%, var(--surface-1));
+}
+
+.simple-file-list,
+.simple-task-list,
+.simple-result-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.simple-file-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--surface-2);
+}
+
+.simple-file-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+.simple-remove-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border: 0;
+  background: transparent;
+  color: var(--on-surface-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 8px;
+  transition: color 140ms ease, background 140ms ease;
+}
+
+.simple-remove-btn:hover {
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+}
+
+.simple-start-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  padding: 14px 24px;
+  border-radius: 14px;
+  border: 0;
+  background: var(--primary);
+  color: #fff;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: 160ms ease;
+}
+
+.simple-start-btn:not(:disabled):hover {
+  background: color-mix(in srgb, var(--primary) 88%, white);
+  transform: translateY(-1px);
+}
+
+.simple-start-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.simple-task-item {
+  display: grid;
+  gap: 6px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: var(--surface-2);
+}
+
+.simple-task-info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.simple-task-info strong {
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.simple-task-stage {
+  color: var(--on-surface-muted);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.simple-task-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.simple-task-progress progress {
+  flex: 1;
+  height: 8px;
+}
+
+.simple-task-percent {
+  font-size: 12px;
+  color: var(--on-surface-muted);
+  min-width: 36px;
+  text-align: right;
+}
+
+.simple-result-item {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: var(--surface-2);
+}
+
+.simple-result-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.simple-result-head strong {
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.simple-open-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--outline);
+  background: var(--surface-1);
+  color: var(--on-surface-muted);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: 9px;
+  cursor: pointer;
+  transition: 140ms ease;
+}
+
+.simple-open-btn:hover {
+  color: var(--on-surface);
+  border-color: var(--primary-border);
+}
+
+.simple-stem-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.simple-stem-item {
+  display: grid;
+  grid-template-columns: minmax(80px, 120px) 1fr;
+  align-items: center;
+  gap: 10px;
+}
+
+.simple-stem-name {
+  font-size: 12px;
+  color: var(--on-surface-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.simple-stem-item audio {
+  width: 100%;
+  height: 36px;
+}
+</style>


### PR DESCRIPTION
## 概述

为 Pymss Studio 增加读屏软件支持(面向视障用户)。本 PR 为**方案 C — 简化操作页 + 主界面全量可达**的设计与实施计划文档,后续按阶段提交代码。

## 范围(已确认)

- **路径 1 — 简化操作页 `/simple`**:线性、语义化、表单驱动,覆盖分离 + 模型管理 + 结果。盲人用户日常走这条。
- **路径 2 — 主界面全量可达**:所有原视图做到 ARIA 完整 + 键盘可操作 + 焦点管理 + 直播区;波形与工作流画布额外做成可驱动。
- **读屏矩阵**:NVDA + Windows 讲述器 + JAWS(试用版)
- **波形策略**:播放 + 口述时间码 + 轨道文本摘要(不做声学声化)
- **后端零改动**:Tauri WebView2 自动暴露 a11y 树,不碰 Rust / Python worker

## 设计文档

- `docs/plans/2025-08-25-screen-reader-support-design.md` — 设计方案(架构决策、简化页路线、各视图落点、测试矩阵)
- `docs/plans/2025-08-25-screen-reader-support-implementation.md` — 实施计划(7 阶段细化,每任务含验收标准/依赖/触及文件)

## 实施计划摘要(7 阶段)

| 阶段 | 内容 | 状态 |
|---|---|---|
| 1 | 原语层(SrText/LiveAnnouncer/FocusTrap/RovingTabindex)+ 全局外壳(焦点环/路由焦点/SideNav) | 待实施 |
| 2 | 简化操作页 `/simple`(盲人核心路径,尽早交付价值) | 待实施 |
| 3 | 对话框审计(8 处手写 role=dialog)+ Toast/进度直播区 | 待实施 |
| 4 | 标准视图查漏(Separate/Models/Results/Settings) | 待实施 |
| 5 | 编辑器(混音器轨道行键盘化 + 波形文本摘要 + 时间码播报) | 待实施 |
| 6 | 工作流图形大纲 + 连接 combobox + 画布可驱动(最深) | 待实施 |
| 7 | axe-core 冒烟 + 快捷键帮助 + 三读屏走查 + 文档 | 待实施 |

每阶段可独立提交、可独立验证;每任务给出验收标准(读屏/键盘/自动三类)与触及文件。详见实施计划文档。

## 基线核对

基于最新 main(`7c1a18e`)重新核对:
- `styles/global.scss` 无 `:focus`/`:focus-visible` 样式 → 焦点环确为空白
- 手写 `role="dialog"` 共 8 处(SeparateView×4、ModelsView、3 个组件)
- 已有地基:`useEditorShortcuts`、`EditorTransportBar` 的 `sr-only`/`aria-pressed`、`SeparateView` 的 `role=listbox/option`

## 当前提交内容

仅设计 + 实施计划两份文档(`docs/` 被 .gitignore 忽略,用 `git add -f` 强制追踪)。代码按阶段后续提交。

## Draft 说明

本 PR 暂为 draft,待阶段 1 代码落地后转 ready。欢迎对设计/计划本身先评审。
